### PR TITLE
Only `na_if()` double or integer columns

### DIFF
--- a/R/gg_area.R
+++ b/R/gg_area.R
@@ -149,7 +149,7 @@ gg_area <- function(
       c(!!x, !!y,
         !!col
       ),
-      function(x) dplyr::na_if(x, Inf)))
+      na_if_double))
 
   #get classes
   x_null <- rlang::quo_is_null(x)

--- a/R/gg_bar.R
+++ b/R/gg_bar.R
@@ -140,7 +140,7 @@ gg_bar <- function(
       c(!!x, !!y,
         !!col
       ),
-      function(x) dplyr::na_if(x, Inf)))
+      na_if_double))
 
   #get classes
   x_null <- rlang::quo_is_null(x)

--- a/R/gg_bin2d.R
+++ b/R/gg_bin2d.R
@@ -134,7 +134,7 @@ gg_bin2d <- function(
     dplyr::ungroup() %>%
     dplyr::mutate(dplyr::across(
       c(!!x, !!y),
-      function(x) dplyr::na_if(x, Inf)))
+      na_if_double))
 
   #get classes
   x_null <- rlang::quo_is_null(x)

--- a/R/gg_blank.R
+++ b/R/gg_blank.R
@@ -196,7 +196,7 @@ gg_blank <- function(
         !!xlower, !!xmiddle, !!xupper, !!ylower, !!ymiddle, !!yupper,
         !!col
       ),
-      function(x) dplyr::na_if(x, Inf)))
+      na_if_double))
 
   #get classes
   if (stat == "sf") {

--- a/R/gg_boxplot.R
+++ b/R/gg_boxplot.R
@@ -180,7 +180,7 @@ gg_boxplot <- function(
         !!xlower, !!xmiddle, !!xupper, !!ylower, !!ymiddle, !!yupper,
         !!col
       ),
-      function(x) dplyr::na_if(x, Inf)))
+      na_if_double))
 
   #get classes
   # x_null <- rlang::quo_is_null(x)

--- a/R/gg_col.R
+++ b/R/gg_col.R
@@ -138,7 +138,7 @@ gg_col <- function(
       c(!!x, !!y,
         !!col
       ),
-      function(x) dplyr::na_if(x, Inf)))
+      na_if_double))
 
   #get classes
   x_null <- rlang::quo_is_null(x)

--- a/R/gg_crossbar.R
+++ b/R/gg_crossbar.R
@@ -162,7 +162,7 @@ gg_crossbar <- function(
         !!xmax, !!ymax,
         !!col
       ),
-      function(x) dplyr::na_if(x, Inf)))
+      na_if_double))
 
   #get classes
   x_null <- rlang::quo_is_null(x) & rlang::quo_is_null(xmin) & rlang::quo_is_null(xmax)

--- a/R/gg_density.R
+++ b/R/gg_density.R
@@ -143,7 +143,7 @@ gg_density <- function(
       c(!!x, !!y,
         !!col
       ),
-      function(x) dplyr::na_if(x, Inf)))
+      na_if_double))
 
   #get classes
   x_null <- rlang::quo_is_null(x)

--- a/R/gg_errorbar.R
+++ b/R/gg_errorbar.R
@@ -176,7 +176,7 @@ gg_errorbar <- function(
         !!xmax, !!ymax,
         !!col
       ),
-      function(x) dplyr::na_if(x, Inf)))
+      na_if_double))
 
   #get classes
   x_null <- rlang::quo_is_null(x) & rlang::quo_is_null(xmin) & rlang::quo_is_null(xmax)

--- a/R/gg_freqpoly.R
+++ b/R/gg_freqpoly.R
@@ -141,7 +141,7 @@ gg_freqpoly <- function(
       c(!!x, !!y,
         !!col
       ),
-      function(x) dplyr::na_if(x, Inf)))
+      na_if_double))
 
   #get classes
   x_null <- rlang::quo_is_null(x)

--- a/R/gg_function.R
+++ b/R/gg_function.R
@@ -138,7 +138,7 @@ gg_function <- function(
       c(!!x, !!y,
         !!col
       ),
-      function(x) dplyr::na_if(x, Inf)))
+      na_if_double))
 
   #get classes
   x_null <- rlang::quo_is_null(x)

--- a/R/gg_hex.R
+++ b/R/gg_hex.R
@@ -134,7 +134,7 @@ gg_hex <- function(
     dplyr::ungroup() %>%
     dplyr::mutate(dplyr::across(
       c(!!x, !!y),
-      function(x) dplyr::na_if(x, Inf)))
+      na_if_double))
 
   #get classes
   x_null <- rlang::quo_is_null(x)

--- a/R/gg_histogram.R
+++ b/R/gg_histogram.R
@@ -144,7 +144,7 @@ gg_histogram <- function(
       c(!!x, !!y,
         !!col
       ),
-      function(x) dplyr::na_if(x, Inf)))
+      na_if_double))
 
   #get classes
   x_null <- rlang::quo_is_null(x)

--- a/R/gg_jitter.R
+++ b/R/gg_jitter.R
@@ -140,7 +140,7 @@ gg_jitter <- function(
       c(!!x, !!y,
         !!col
       ),
-      function(x) dplyr::na_if(x, Inf)))
+      na_if_double))
 
   #get classes
   x_null <- rlang::quo_is_null(x)

--- a/R/gg_label.R
+++ b/R/gg_label.R
@@ -141,7 +141,7 @@ gg_label <- function(
       c(!!x, !!y,
         !!col
       ),
-      function(x) dplyr::na_if(x, Inf)))
+      na_if_double))
 
   #get classes
   x_null <- rlang::quo_is_null(x)

--- a/R/gg_line.R
+++ b/R/gg_line.R
@@ -145,7 +145,7 @@ gg_line <- function(
       c(!!x, !!y,
         !!col
       ),
-      function(x) dplyr::na_if(x, Inf)))
+      na_if_double))
 
   #get classes
   x_null <- rlang::quo_is_null(x)

--- a/R/gg_linerange.R
+++ b/R/gg_linerange.R
@@ -163,7 +163,7 @@ gg_linerange <- function(
         !!xmax, !!ymax,
         !!col
       ),
-      function(x) dplyr::na_if(x, Inf)))
+      na_if_double))
 
   #get classes
   x_null <- rlang::quo_is_null(x) & rlang::quo_is_null(xmin) & rlang::quo_is_null(xmax)

--- a/R/gg_path.R
+++ b/R/gg_path.R
@@ -140,7 +140,7 @@ gg_path <- function(
       c(!!x, !!y,
         !!col
       ),
-      function(x) dplyr::na_if(x, Inf)))
+      na_if_double))
 
   #get classes
   x_null <- rlang::quo_is_null(x)

--- a/R/gg_point.R
+++ b/R/gg_point.R
@@ -145,7 +145,7 @@ gg_point <- function(
       c(!!x, !!y,
         !!col
       ),
-      function(x) dplyr::na_if(x, Inf)))
+      na_if_double))
 
   #get classes
   x_null <- rlang::quo_is_null(x)

--- a/R/gg_pointrange.R
+++ b/R/gg_pointrange.R
@@ -163,7 +163,7 @@ gg_pointrange <- function(
         !!xmax, !!ymax,
         !!col
       ),
-      function(x) dplyr::na_if(x, Inf)))
+      na_if_double))
 
   #get classes
   x_null <- rlang::quo_is_null(x) & rlang::quo_is_null(xmin) & rlang::quo_is_null(xmax)

--- a/R/gg_polygon.R
+++ b/R/gg_polygon.R
@@ -181,7 +181,7 @@ gg_polygon <- function(
       c(!!x, !!y,
         !!col
       ),
-      function(x) dplyr::na_if(x, Inf)))
+      na_if_double))
 
   #get classes
   x_null <- rlang::quo_is_null(x)

--- a/R/gg_qq.R
+++ b/R/gg_qq.R
@@ -143,7 +143,7 @@ gg_qq <- function(
       c(!!x, !!y, !!sample,
         !!col
       ),
-      function(x) dplyr::na_if(x, Inf)))
+      na_if_double))
 
   #get classes
   x_null <- rlang::quo_is_null(x)

--- a/R/gg_raster.R
+++ b/R/gg_raster.R
@@ -143,7 +143,7 @@ gg_raster <- function(
       c(!!x, !!y,
         !!col
       ),
-      function(x) dplyr::na_if(x, Inf)))
+      na_if_double))
 
   #get classes
   x_null <- rlang::quo_is_null(x)

--- a/R/gg_rect.R
+++ b/R/gg_rect.R
@@ -163,7 +163,7 @@ gg_rect <- function(
         !!xmax, !!ymax,
         !!col
       ),
-      function(x) dplyr::na_if(x, Inf)))
+      na_if_double))
 
   #get classes
   x_null <- rlang::quo_is_null(x) & rlang::quo_is_null(xmin) & rlang::quo_is_null(xmax)

--- a/R/gg_ribbon.R
+++ b/R/gg_ribbon.R
@@ -170,7 +170,7 @@ gg_ribbon <- function(
         !!xmax, !!ymax,
         !!col
       ),
-      function(x) dplyr::na_if(x, Inf)))
+      na_if_double))
 
   #get classes
   x_null <- rlang::quo_is_null(x) & rlang::quo_is_null(xmin) & rlang::quo_is_null(xmax)

--- a/R/gg_segment.R
+++ b/R/gg_segment.R
@@ -147,7 +147,7 @@ gg_segment <- function(
         !!xend, !!yend,
         !!col
       ),
-      function(x) dplyr::na_if(x, Inf)))
+      na_if_double))
 
   #get classes
   # x_null <- rlang::quo_is_null(x)

--- a/R/gg_sf.R
+++ b/R/gg_sf.R
@@ -105,7 +105,7 @@ gg_sf <- function(
     dplyr::ungroup() %>%
     dplyr::mutate(dplyr::across(
       c(!!col),
-      function(x) dplyr::na_if(x, Inf)))
+      na_if_double))
 
   #get classes
   x_null <- TRUE

--- a/R/gg_smooth.R
+++ b/R/gg_smooth.R
@@ -150,7 +150,7 @@ gg_smooth <- function(
       c(!!x, !!y,
         !!col
       ),
-      function(x) dplyr::na_if(x, Inf)))
+      na_if_double))
 
   #get classes
   x_null <- rlang::quo_is_null(x)

--- a/R/gg_step.R
+++ b/R/gg_step.R
@@ -138,7 +138,7 @@ gg_step <- function(
       c(!!x, !!y,
         !!col
       ),
-      function(x) dplyr::na_if(x, Inf)))
+      na_if_double))
 
   #get classes
   x_null <- rlang::quo_is_null(x)

--- a/R/gg_text.R
+++ b/R/gg_text.R
@@ -140,7 +140,7 @@ gg_text <- function(
       c(!!x, !!y,
         !!col
       ),
-      function(x) dplyr::na_if(x, Inf)))
+      na_if_double))
 
   #get classes
   x_null <- rlang::quo_is_null(x)

--- a/R/gg_tile.R
+++ b/R/gg_tile.R
@@ -147,7 +147,7 @@ gg_tile <- function(
       c(!!x, !!y,
         !!col
       ),
-      function(x) dplyr::na_if(x, Inf)))
+      na_if_double))
 
   #get classes
   x_null <- rlang::quo_is_null(x)

--- a/R/gg_violin.R
+++ b/R/gg_violin.R
@@ -139,7 +139,7 @@ gg_violin <- function(
       c(!!x, !!y,
         !!col
       ),
-      function(x) dplyr::na_if(x, Inf)))
+      na_if_double))
 
   #get classes
   x_null <- rlang::quo_is_null(x)

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,0 +1,15 @@
+na_if_double <- function(x) {
+  if (is.object(x)) {
+    return(x)
+  }
+
+  if (is.integer(x)) {
+    x <- as.double(x)
+  }
+
+  if (is.numeric(x)) {
+    x <- dplyr::na_if(x, Inf)
+  }
+
+  x
+}


### PR DESCRIPTION
This PR makes your package compatible with the next version of dplyr:

`na_if()` now uses vctrs. It also now casts `y` to the type of `x` to ensure that it is type stable on `x` (the primary input). This means it is now a little stricter. In your case you were calling `na_if(x, Inf)` and `x` was possibly a double, Date, factor, or character, and really only the first of those was ever supposed to work. I've worked around this by creating a wrapper that skips the `na_if()` if the input isn't a double or integer vector.

We plan to submit dplyr 1.1.0 on January 27th.

This should be compatible with both dev and CRAN dplyr. It would help us out if you could go ahead and send a patch version of your package to CRAN ahead of time! Thanks!