### PR TITLE
Minor edits to documentation

### DIFF
--- a/R/gg_area.R
+++ b/R/gg_area.R
@@ -1,6 +1,6 @@
 #' @title Area ggplot
 #'
-#' @description Create an area ggplot with a wrapper around ggplot() + geom_area.
+#' @description Create an area ggplot with a wrapper around `ggplot()` + [geom_area()][ggplot2::geom_area()].
 #'
 #' @inheritParams gg_blanket
 #'

--- a/R/gg_bar.R
+++ b/R/gg_bar.R
@@ -1,6 +1,6 @@
 #' @title Bar ggplot
 #'
-#' @description Create a bar ggplot with a wrapper around ggplot() + geom_bar.
+#' @description Create a bar ggplot with a wrapper around `ggplot()` + [geom_bar()][ggplot2::geom_bar()].
 #'
 #' @inheritParams gg_blanket
 #'

--- a/R/gg_bin_2d.R
+++ b/R/gg_bin_2d.R
@@ -1,6 +1,6 @@
 #' @title Bin_2d ggplot
 #'
-#' @description Create a bin2d ggplot with a wrapper around ggplot() + geom_bin_2d.
+#' @description Create a bin2d ggplot with a wrapper around `ggplot()` + [geom_bin_2d()][ggplot2::geom_bin_2d()].
 #'
 #' @inheritParams gg_blanket
 #'

--- a/R/gg_blanket.R
+++ b/R/gg_blanket.R
@@ -1,87 +1,76 @@
 #' @title Blanket ggplot with geom flexibility
 #'
-#' @description Create a blanket ggplot with a wrapper around ggplot() + layer() with geom_blank defaults.
+#' @description Create a blanket ggplot with a wrapper around `ggplot()` + `layer()` with [geom_blank()][ggplot2::geom_blank()] defaults.
 #'
 #' @param data A data frame or tibble.
-#' @param ... Other arguments passed to within a params list in the layer function.
+#' @param ... Other arguments passed to within a `params` list in `layer()`.
 #' @param geom A geometric object to display the data. A snakecase character string of a ggproto Geom subclass object minus the Geom prefix (e.g. "point").
 #' @param stat A statistical transformation to use on the data. A snakecase character string of a ggproto Stat subclass object minus the Stat prefix (e.g. "identity").
-#' @param position A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a position_* function that outputs a ggproto Position subclass object (e.g. ggplot2::position_identity()).
-#' @param coord A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. ggplot2::coord_cartesian()).
-#' @param theme A ggplot2 theme (e.g. light_mode_b(), dark_mode_rt() or ggplot2::theme_grey()).
-#' @param x Unquoted x aesthetic variable.
-#' @param xmin Unquoted xmin aesthetic variable.
-#' @param xmax Unquoted xmax aesthetic variable.
-#' @param xend Unquoted xend aesthetic variable.
-#' @param y Unquoted y aesthetic variable.
-#' @param ymin Unquoted ymin aesthetic variable.
-#' @param ymax Unquoted ymax aesthetic variable.
-#' @param yend Unquoted yend aesthetic variable.
-#' @param z Unquoted z aesthetic variable.
-#' @param col Unquoted col and fill aesthetic variable.
-#' @param alpha Unquoted alpha aesthetic variable.
-#' @param facet Unquoted facet aesthetic variable.
+#' @param position A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a `position_*()` function that outputs a ggproto Position subclass object (e.g. `ggplot2::position_identity()`).
+#' @param coord A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. [ggplot2::coord_cartesian()]).
+#' @param theme A ggplot2 theme (e.g. [light_mode_b()], [dark_mode_rt()] or [ggplot2::theme_grey()]).
+#' @param x Unquoted `x` aesthetic variable.
+#' @param xmin Unquoted `xmin` aesthetic variable.
+#' @param xmax Unquoted `xmax` aesthetic variable.
+#' @param xend Unquoted `xend` aesthetic variable.
+#' @param y Unquoted `y` aesthetic variable.
+#' @param ymin Unquoted `ymin` aesthetic variable.
+#' @param ymax Unquoted `ymax` aesthetic variable.
+#' @param yend Unquoted `yend` aesthetic variable.
+#' @param z Unquoted `z` aesthetic variable.
+#' @param col Unquoted `col` and `fill` aesthetic variable.
+#' @param alpha Unquoted `alpha` aesthetic variable.
+#' @param facet Unquoted `facet` aesthetic variable.
 #' @param facet2 Unquoted second facet variable.
-#' @param group Unquoted group aesthetic variable.
-#' @param subgroup Unquoted subgroup aesthetic variable.
-#' @param label Unquoted label aesthetic variable.
-#' @param text Unquoted text aesthetic variable.
-#' @param sample Unquoted sample aesthetic variable.
-#' @param mapping Set of additional aesthetic mappings within the ggplot2::aes function for non-supported aesthetics (e.g. shape, linetype, linewidth, or size) or for delayed evaluation.
-#' @param x_breaks A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.
-#' @param x_expand Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).
-#' @param x_expand_limits For a continuous x variable, any values that the limits should encompass (e.g. 0).
-#' @param x_gridlines TRUE or FALSE for vertical x gridlines. NULL guesses based on the classes of the x and y.
-#' @param x_labels A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.
-#' @param x_limits A vector of length 2 to determine the limits of the axis.
-#' @param x_oob For a continuous x variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.
-#' @param x_sec_axis A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.
-#' @param x_title Axis title string. Use "" for no title.
-#' @param x_transform For a numeric x variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").
-#' @param y_breaks A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.
-#' @param y_expand Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).
-#' @param y_expand_limits For a continuous y variable, any values that the limits should encompass (e.g. 0).
-#' @param y_gridlines TRUE or FALSE of horizontal y gridlines. NULL guesses based on the classes of the x and y.
-#' @param y_labels A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.
-#' @param y_limits A vector of length 2 to determine the limits of the axis.
-#' @param y_oob For a continuous y variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.
-#' @param y_sec_axis A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.
-#' @param y_title Axis title string. Use "" for no title.
-#' @param y_transform For a numeric y variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").
-#' @param col_breaks A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.
+#' @param group Unquoted `group` aesthetic variable.
+#' @param subgroup Unquoted `subgroup` aesthetic variable.
+#' @param label Unquoted `label` aesthetic variable.
+#' @param text Unquoted `text` aesthetic variable.
+#' @param sample Unquoted `sample` aesthetic variable.
+#' @param mapping Set of additional aesthetic mappings within `ggplot2::aes()` for non-supported aesthetics (e.g. `shape`, `linetype`, `linewidth`, or `size`) or for delayed evaluation.
+#' @param x_breaks,y_breaks A `scales::breaks_*` function (e.g. [scales::breaks_pretty()]), or a vector of breaks.
+#' @param x_expand,y_expand Padding to the limits with the `ggplot2::expansion()` function, or a vector of length 2 (e.g. `c(0, 0)`).
+#' @param x_expand_limits,y_expand_limits For a continuous variable, any values that the limits should encompass (e.g. 0).
+#' @param x_gridlines `TRUE` or `FALSE` for vertical `x` gridlines. `NULL` guesses based on the classes of the x and y.
+#' @param x_labels,y_labels A function that takes the breaks as inputs (e.g. `\(x) stringr::str_to_sentence(x)` or [scales::label_comma()]), or a vector of labels.
+#' @param x_limits,y_limits A vector of length 2 to determine the limits of the axis.
+#' @param x_oob,y_oob For a continuous `x` variable, a `scales::oob_*` function of how to handle values outside of limits (e.g. `scales::oob_keep`). Defaults to `scales::oob_keep`.
+#' @param x_sec_axis,y_sec_axis A secondary axis using `ggplot2::sec_axis()` or `ggplot2::dup_axis()`.
+#' @param x_title,y_title Axis title string. Use `""` for no title.
+#' @param x_transform,y_transform For a numeric variable, a transformation object (e.g. `scales::transform_log10()`) or character string of this minus the `transform_` prefix (e.g. "log10").
+#' @param y_gridlines `TRUE` or `FALSE` of horizontal `y` gridlines. `NULL` guesses based on the classes of the `x` and `y`.
+#' @param col_breaks A `scales::breaks_*` function (e.g. `scales::breaks_pretty()`), or a vector of breaks.
 #' @param col_continuous_type For a continuous variable, whether to colour as a "gradient" or in "steps". Defaults to "gradient".
-#' @param col_expand Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).
+#' @param col_expand Padding to the limits with `ggplot2::expansion()`, or a vector of length 2 (e.g. `c(0, 0)`).
 #' @param col_expand_limits For a continuous variable, any values that the limits should encompass (e.g. 0).
-#' @param col_labels A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.
-#' @param col_legend_ncol The number of columns for the legend elements.
-#' @param col_legend_nrow The number of rows for the legend elements.
-#' @param col_legend_rev Reverse the elements of the legend. Defaults to FALSE.
+#' @param col_labels A function that takes the breaks as inputs (e.g. `\(x) stringr::str_to_sentence(x)` or `scales::label_comma()`), or a vector of labels.
+#' @param col_legend_ncol,col_legend_nrow The number of columns and rows for the legend elements.
+#' @param col_legend_rev Reverse the elements of the legend. Defaults to `FALSE`.
 #' @param col_limits A vector to determine the limits of the scale.
-#' @param col_oob For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.
+#' @param col_oob For a continuous variable, a `scales::oob_*` function of how to handle values outside of limits (e.g. `scales::oob_keep`). Defaults to `scales::oob_keep`.
 #' @param col_pal colours to use. A character vector of hex codes (or names).
-#' @param col_pal_na colour to use for NA values. A character vector of a hex code (or name).
-#' @param col_rescale For a continuous variable, a scales::rescale function.
+#' @param col_pal_na colour to use for `NA` values. A character vector of a hex code (or name).
+#' @param col_rescale For a continuous variable, a `scales::rescale` function.
 #' @param col_title Legend title string. Use "" for no title.
-#' @param col_transform For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").
-#' @param alpha_breaks A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.
-#' @param alpha_expand Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).
+#' @param col_transform For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the `transform_` prefix (e.g. "log10").
+#' @param alpha_breaks A `scales::breaks_*` function (e.g. `scales::breaks_pretty()`), or a vector of breaks.
+#' @param alpha_expand Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. `c(0, 0)`).
 #' @param alpha_expand_limits For a continuous variable, any values that the limits should encompass (e.g. 0).
-#' @param alpha_labels A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.
-#' @param alpha_legend_ncol The number of columns for the legend elements.
-#' @param alpha_legend_nrow The number of rows for the legend elements.
-#' @param alpha_legend_rev Reverse the elements of the legend. Defaults to FALSE.
+#' @param alpha_labels A function that takes the breaks as inputs (e.g. `\(x) stringr::str_to_sentence(x)` or `scales::label_comma()`), or a vector of labels.
+#' @param alpha_legend_ncol,alpha_legend_nrow The number of columns and rows for the legend elements.
+#' @param alpha_legend_rev Reverse the elements of the legend. Defaults to `FALSE`.
 #' @param alpha_limits A vector to determine the limits of the scale.
-#' @param alpha_oob For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.
+#' @param alpha_oob For a continuous variable, a `scales::oob_*` function of how to handle values outside of limits (e.g. `scales::oob_keep`). Defaults to `scales::oob_keep`.
 #' @param alpha_pal Alpha values to use as a numeric vector. For a continuous variable, a range is only needed.
-#' @param alpha_pal_na Alpha value to use for the NA value.
-#' @param alpha_title Legend title string. Use "" for no title.
-#' @param alpha_transform For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").
+#' @param alpha_pal_na Alpha value to use for the `NA` value.
+#' @param alpha_title Legend title string. Use `""` for no title.
+#' @param alpha_transform For a numeric variable, a transformation object (e.g. `scales::transform_log10()`) or character string of this minus the transform_ prefix (e.g. "log10").
 #' @param facet_axes Whether to add interior axes and ticks with "margins", "all", "all_x", or "all_y".
 #' @param facet_axis_labels Whether to add interior axis labels with "margins", "all", "all_x", or "all_y".
-#' @param facet_labels A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a named vector of labels (e.g. c("value1" = "label1", ...)).
+#' @param facet_labels A function that takes the breaks as inputs (e.g. `\(x) stringr::str_to_sentence(x)` or `scales::label_comma()`), or a named vector of labels (e.g. c("value1" = "label1", ...)).
 #' @param facet_labels_position When the facet layout is "wrap", the position of the facet labels. Either "top", "right", "bottom" or "left".
 #' @param facet_labels_switch When the facet layout is "grid", whether to switch the facet labels to the opposite side of the plot. Either "x", "y" or "both".
-#' @param facet_layout Whether the layout is to be "wrap" or "grid". If NULL and a single facet (or facet2) argument is provided, then defaults to "wrap". If NULL and both facet and facet2 arguments are provided, defaults to "grid".
+#' @param facet_layout Whether the layout is to be "wrap" or "grid". If `NULL` and a single `facet` (or `facet2`) argument is provided, then defaults to "wrap". If `NULL` and both facet and facet2 arguments are provided, defaults to "grid".
 #' @param facet_ncol The number of columns of facets. Only applies to a facet layout of "wrap".
 #' @param facet_nrow The number of rows of facets. Only applies to a facet layout of "wrap".
 #' @param facet_scales Whether facet scales should be "fixed" across facets, "free" in both directions, or free in just one direction (i.e. "free_x" or "free_y"). Defaults to "fixed".
@@ -89,8 +78,8 @@
 #' @param title Title string.
 #' @param subtitle Subtitle string.
 #' @param caption Caption title string.
-#' @param titles A function to format unspecified titles. Defaults to snakecase::to_sentence_case.
-#' @param flipped TRUE or FALSE or whether the plot is flipped. This affects the defaults of positional scale and gridlines.
+#' @param titles A function to format unspecified titles. Defaults to `snakecase::to_sentence_case`.
+#' @param flipped `TRUE` or `FALSE` or whether the plot is flipped. This affects the defaults of positional scale and gridlines.
 #'
 #' @return A ggplot object.
 #' @export

--- a/R/gg_boxplot.R
+++ b/R/gg_boxplot.R
@@ -1,6 +1,6 @@
 #' @title Boxplot ggplot
 #'
-#' @description Create a boxplot ggplot with a wrapper around ggplot() + geom_boxplot.
+#' @description Create a boxplot ggplot with a wrapper around `ggplot()` + [geom_boxplot()][ggplot2::geom_boxplot()].
 #'
 #' @inheritParams gg_blanket
 #'

--- a/R/gg_col.R
+++ b/R/gg_col.R
@@ -1,6 +1,6 @@
 #' @title Col ggplot
 #'
-#' @description Create a col ggplot with a wrapper around ggplot() + geom_col.
+#' @description Create a col ggplot with a wrapper around `ggplot()` + [geom_col()][ggplot2::geom_col()].
 #'
 #' @inheritParams gg_blanket
 #'

--- a/R/gg_contour.R
+++ b/R/gg_contour.R
@@ -1,6 +1,6 @@
 #' @title Contour ggplot
 #'
-#' @description Create a contour ggplot with a wrapper around ggplot() + geom_contour.
+#' @description Create a contour ggplot with a wrapper around `ggplot()` + [geom_contour()][ggplot2::geom_contour()].
 #'
 #' @inheritParams gg_blanket
 #'

--- a/R/gg_contour_filled.R
+++ b/R/gg_contour_filled.R
@@ -1,6 +1,6 @@
 #' @title Contour_filled ggplot
 #'
-#' @description Create a contour_filled ggplot with a wrapper around ggplot() + geom_contour_filled.
+#' @description Create a contour_filled ggplot with a wrapper around `ggplot()` + [geom_contour_filled()][ggplot2::geom_contour_filled()].
 #'
 #' @inheritParams gg_blanket
 #'

--- a/R/gg_crossbar.R
+++ b/R/gg_crossbar.R
@@ -1,6 +1,6 @@
 #' @title Crossbar ggplot
 #'
-#' @description Create a crossbar ggplot with a wrapper around ggplot() + geom_crossbar.
+#' @description Create a crossbar ggplot with a wrapper around `ggplot()` + [geom_crossbar()][ggplot2::geom_crossbar()].
 #'
 #' @inheritParams gg_blanket
 #'

--- a/R/gg_density.R
+++ b/R/gg_density.R
@@ -1,6 +1,6 @@
 #' @title Density ggplot
 #'
-#' @description Create a density ggplot with a wrapper around ggplot() + geom_density.
+#' @description Create a density ggplot with a wrapper around `ggplot()` + [geom_density()][ggplot2::geom_density()].
 #'
 #' @inheritParams gg_blanket
 #'

--- a/R/gg_density_2d.R
+++ b/R/gg_density_2d.R
@@ -1,6 +1,6 @@
 #' @title Density_2d ggplot
 #'
-#' @description Create a density_2d ggplot with a wrapper around ggplot() + geom_density_2d.
+#' @description Create a density_2d ggplot with a wrapper around `ggplot()` + [geom_density_2d()][ggplot2::geom_density_2d()].
 #'
 #' @inheritParams gg_blanket
 #'

--- a/R/gg_density_2d_filled.R
+++ b/R/gg_density_2d_filled.R
@@ -1,6 +1,6 @@
 #' @title Density_2d_filled ggplot
 #'
-#' @description Create a density_2d_filled ggplot with a wrapper around ggplot() + geom_density_2d_filled.
+#' @description Create a density_2d_filled ggplot with a wrapper around `ggplot()` + [geom_density_2d_filled()][ggplot2::geom_density_2d_filled()].
 #'
 #' @inheritParams gg_blanket
 #'

--- a/R/gg_errorbar.R
+++ b/R/gg_errorbar.R
@@ -1,6 +1,6 @@
 #' @title Errorbar ggplot
 #'
-#' @description Create a errorbar ggplot with a wrapper around ggplot() + geom_errorbar.
+#' @description Create a errorbar ggplot with a wrapper around `ggplot()` + [geom_errorbar()][ggplot2::geom_errorbar()].
 #'
 #' @inheritParams gg_blanket
 #'

--- a/R/gg_freqpoly.R
+++ b/R/gg_freqpoly.R
@@ -1,6 +1,6 @@
 #' @title Freqpoly ggplot
 #'
-#' @description Create a freqpoly ggplot with a wrapper around ggplot() + geom_freqpoly.
+#' @description Create a freqpoly ggplot with a wrapper around `ggplot()` + [geom_freqpoly()][ggplot2::geom_freqpoly()].
 #'
 #' @inheritParams gg_blanket
 #'

--- a/R/gg_function.R
+++ b/R/gg_function.R
@@ -1,6 +1,6 @@
 #' @title Function ggplot
 #'
-#' @description Create a function ggplot with a wrapper around ggplot() + geom_function.
+#' @description Create a function ggplot with a wrapper around `ggplot()` + [geom_function()][ggplot2::geom_function()].
 #'
 #' @inheritParams gg_blanket
 #'

--- a/R/gg_hex.R
+++ b/R/gg_hex.R
@@ -1,6 +1,6 @@
 #' @title Hex ggplot
 #'
-#' @description Create a hex ggplot with a wrapper around ggplot() + geom_hex.
+#' @description Create a hex ggplot with a wrapper around `ggplot()` + [geom_hex()][ggplot2::geom_hex()].
 #'
 #' @inheritParams gg_blanket
 #'

--- a/R/gg_histogram.R
+++ b/R/gg_histogram.R
@@ -1,6 +1,6 @@
 #' @title Histogram ggplot
 #'
-#' @description Create a histogram ggplot with a wrapper around ggplot() + geom_histogram.
+#' @description Create a histogram ggplot with a wrapper around `ggplot()` + [geom_histogram()][ggplot2::geom_histogram()].
 #'
 #' @inheritParams gg_blanket
 #'

--- a/R/gg_jitter.R
+++ b/R/gg_jitter.R
@@ -1,6 +1,6 @@
 #' @title Jitter ggplot
 #'
-#' @description Create a jitter ggplot with a wrapper around ggplot() + geom_jitter.
+#' @description Create a jitter ggplot with a wrapper around `ggplot()` + [geom_jitter()][ggplot2::geom_jitter()].
 #'
 #' @inheritParams gg_blanket
 #'

--- a/R/gg_label.R
+++ b/R/gg_label.R
@@ -1,6 +1,6 @@
 #' @title Label ggplot
 #'
-#' @description Create a label ggplot with a wrapper around ggplot() + geom_label.
+#' @description Create a label ggplot with a wrapper around `ggplot()` + [geom_label()][ggplot2::geom_label()].
 #'
 #' @inheritParams gg_blanket
 #'

--- a/R/gg_line.R
+++ b/R/gg_line.R
@@ -1,6 +1,6 @@
 #' @title Line ggplot
 #'
-#' @description Create a line ggplot with a wrapper around ggplot() + geom_line.
+#' @description Create a line ggplot with a wrapper around `ggplot()` + [geom_line()][ggplot2::geom_line()].
 #'
 #' @inheritParams gg_blanket
 #'

--- a/R/gg_linerange.R
+++ b/R/gg_linerange.R
@@ -1,6 +1,6 @@
 #' @title Linerange ggplot
 #'
-#' @description Create a linerange ggplot with a wrapper around ggplot() + geom_linerange.
+#' @description Create a linerange ggplot with a wrapper around `ggplot()` + [geom_linerange()][ggplot2::geom_linerange()].
 #'
 #' @inheritParams gg_blanket
 #'

--- a/R/gg_path.R
+++ b/R/gg_path.R
@@ -1,6 +1,6 @@
 #' @title Path ggplot
 #'
-#' @description Create a path ggplot with a wrapper around ggplot() + geom_path.
+#' @description Create a path ggplot with a wrapper around `ggplot()` + [geom_path()][ggplot2::geom_path()].
 #'
 #' @inheritParams gg_blanket
 #'

--- a/R/gg_point.R
+++ b/R/gg_point.R
@@ -1,6 +1,6 @@
 #' @title Point ggplot
 #'
-#' @description Create a point ggplot with a wrapper around ggplot() + geom_point.
+#' @description Create a point ggplot with a wrapper around `ggplot()` + [geom_point()][ggplot2::geom_point()].
 #'
 #' @inheritParams gg_blanket
 #'

--- a/R/gg_pointrange.R
+++ b/R/gg_pointrange.R
@@ -1,6 +1,6 @@
 #' @title Pointrange ggplot
 #'
-#' @description Create a pointrange ggplot with a wrapper around ggplot() + geom_pointrange.
+#' @description Create a pointrange ggplot with a wrapper around `ggplot()` + [geom_pointrange()][ggplot2::geom_pointrange()].
 #'
 #' @inheritParams gg_blanket
 #'

--- a/R/gg_polygon.R
+++ b/R/gg_polygon.R
@@ -1,6 +1,6 @@
 #' @title Polygon ggplot
 #'
-#' @description Create a polygon ggplot with a wrapper around ggplot() + geom_polygon.
+#' @description Create a polygon ggplot with a wrapper around `ggplot()` + [geom_polygon()][ggplot2::geom_polygon()].
 #'
 #' @inheritParams gg_blanket
 #'

--- a/R/gg_qq.R
+++ b/R/gg_qq.R
@@ -1,6 +1,6 @@
 #' @title Qq ggplot
 #'
-#' @description Create a qq ggplot with a wrapper around ggplot() + geom_qq.
+#' @description Create a qq ggplot with a wrapper around `ggplot()` + [geom_qq()][ggplot2::geom_qq()].
 #'
 #' @inheritParams gg_blanket
 #'

--- a/R/gg_quantile.R
+++ b/R/gg_quantile.R
@@ -1,6 +1,6 @@
 #' @title Quantile ggplot
 #'
-#' @description Create an quantile ggplot with a wrapper around ggplot() + geom_quantile.
+#' @description Create an quantile ggplot with a wrapper around `ggplot()` + [geom_quantile()][ggplot2::geom_quantile()].
 #'
 #' @inheritParams gg_blanket
 #'

--- a/R/gg_raster.R
+++ b/R/gg_raster.R
@@ -1,6 +1,6 @@
 #' @title Raster ggplot
 #'
-#' @description Create a raster ggplot with a wrapper around ggplot() + geom_raster.
+#' @description Create a raster ggplot with a wrapper around `ggplot()` + [geom_raster()][ggplot2::geom_raster()].
 #'
 #' @inheritParams gg_blanket
 #'

--- a/R/gg_rect.R
+++ b/R/gg_rect.R
@@ -1,6 +1,6 @@
 #' @title Rect ggplot
 #'
-#' @description Create a rect ggplot with a wrapper around ggplot() + geom_rect.
+#' @description Create a rect ggplot with a wrapper around `ggplot()` + [geom_rect()][ggplot2::geom_rect()].
 #'
 #' @inheritParams gg_blanket
 #'

--- a/R/gg_ribbon.R
+++ b/R/gg_ribbon.R
@@ -1,6 +1,6 @@
 #' @title Ribbon ggplot
 #'
-#' @description Create a ribbon ggplot with a wrapper around ggplot() + geom_ribbon.
+#' @description Create a ribbon ggplot with a wrapper around `ggplot()` + [geom_ribbon()][ggplot2::geom_ribbon()]
 #'
 #' @inheritParams gg_blanket
 #'

--- a/R/gg_rug.R
+++ b/R/gg_rug.R
@@ -1,6 +1,6 @@
 #' @title Rug ggplot
 #'
-#' @description Create a rug ggplot with a wrapper around ggplot() + geom_rug.
+#' @description Create a rug ggplot with a wrapper around `ggplot()` + [geom_rug()][ggplot2::geom_rug()].
 #'
 #' @inheritParams gg_blanket
 #'

--- a/R/gg_segment.R
+++ b/R/gg_segment.R
@@ -1,6 +1,6 @@
 #' @title Segment ggplot
 #'
-#' @description Create a segment ggplot with a wrapper around ggplot() + geom_segment.
+#' @description Create a segment ggplot with a wrapper around `ggplot()` + [geom_segment()][ggplot2::geom_segment()].
 #'
 #' @inheritParams gg_blanket
 #'

--- a/R/gg_sf.R
+++ b/R/gg_sf.R
@@ -1,6 +1,6 @@
 #' @title Sf ggplot
 #'
-#' @description Create a blank ggplot with a wrapper around ggplot() + geom_sf.
+#' @description Create a blank ggplot with a wrapper around `ggplot()` + [geom_sf()][ggplot2::geom_sf()].
 #'
 #' @inheritParams gg_blanket
 #'

--- a/R/gg_smooth.R
+++ b/R/gg_smooth.R
@@ -1,6 +1,6 @@
 #' @title Smooth ggplot
 #'
-#' @description Create a smooth ggplot with a wrapper around ggplot() + geom_smooth.
+#' @description Create a smooth ggplot with a wrapper around `ggplot()` + [geom_smooth()][ggplot2::geom_smooth()].
 #'
 #' @inheritParams gg_blanket
 #'

--- a/R/gg_step.R
+++ b/R/gg_step.R
@@ -1,6 +1,6 @@
 #' @title Step ggplot
 #'
-#' @description Create a step plot with a wrapper around ggplot() + geom_step.
+#' @description Create a step plot with a wrapper around `ggplot()` + [geom_step()][ggplot2::geom_step()].
 #'
 #' @inheritParams gg_blanket
 #'

--- a/R/gg_text.R
+++ b/R/gg_text.R
@@ -1,6 +1,6 @@
 #' @title Text ggplot
 #'
-#' @description Create a text plot with a wrapper around ggplot() + geom_text.
+#' @description Create a text plot with a wrapper around `ggplot()` + [geom_text()][ggplot2::geom_text()].
 #'
 #' @inheritParams gg_blanket
 #'

--- a/R/gg_tile.R
+++ b/R/gg_tile.R
@@ -1,6 +1,6 @@
 #' @title Tile ggplot
 #'
-#' @description Create a tile plot with a wrapper around ggplot() + geom_tile.
+#' @description Create a tile plot with a wrapper around `ggplot()` + [geom_tile()][ggplot2::geom_tile()].
 #'
 #' @inheritParams gg_blanket
 #'

--- a/R/gg_violin.R
+++ b/R/gg_violin.R
@@ -1,6 +1,6 @@
 #' @title Violin ggplot
 #'
-#' @description Create a violin plot with a wrapper around ggplot() + geom_violin.
+#' @description Create a violin plot with a wrapper around `ggplot()` + [geom_violin()][ggplot2::geom_violin()].
 #'
 #' @inheritParams gg_blanket
 #'

--- a/man/gg_area.Rd
+++ b/man/gg_area.Rd
@@ -98,161 +98,139 @@ gg_area(
 \arguments{
 \item{data}{A data frame or tibble.}
 
-\item{...}{Other arguments passed to within a params list in the layer function.}
+\item{...}{Other arguments passed to within a \code{params} list in \code{layer()}.}
 
 \item{stat}{A statistical transformation to use on the data. A snakecase character string of a ggproto Stat subclass object minus the Stat prefix (e.g. "identity").}
 
-\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a position_* function that outputs a ggproto Position subclass object (e.g. ggplot2::position_identity()).}
+\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a \verb{position_*()} function that outputs a ggproto Position subclass object (e.g. \code{ggplot2::position_identity()}).}
 
-\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. ggplot2::coord_cartesian()).}
+\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. \code{\link[ggplot2:coord_cartesian]{ggplot2::coord_cartesian()}}).}
 
-\item{theme}{A ggplot2 theme (e.g. light_mode_b(), dark_mode_rt() or ggplot2::theme_grey()).}
+\item{theme}{A ggplot2 theme (e.g. \code{\link[=light_mode_b]{light_mode_b()}}, \code{\link[=dark_mode_rt]{dark_mode_rt()}} or \code{\link[ggplot2:ggtheme]{ggplot2::theme_grey()}}).}
 
-\item{x}{Unquoted x aesthetic variable.}
+\item{x}{Unquoted \code{x} aesthetic variable.}
 
-\item{xmin}{Unquoted xmin aesthetic variable.}
+\item{xmin}{Unquoted \code{xmin} aesthetic variable.}
 
-\item{xmax}{Unquoted xmax aesthetic variable.}
+\item{xmax}{Unquoted \code{xmax} aesthetic variable.}
 
-\item{xend}{Unquoted xend aesthetic variable.}
+\item{xend}{Unquoted \code{xend} aesthetic variable.}
 
-\item{y}{Unquoted y aesthetic variable.}
+\item{y}{Unquoted \code{y} aesthetic variable.}
 
-\item{ymin}{Unquoted ymin aesthetic variable.}
+\item{ymin}{Unquoted \code{ymin} aesthetic variable.}
 
-\item{ymax}{Unquoted ymax aesthetic variable.}
+\item{ymax}{Unquoted \code{ymax} aesthetic variable.}
 
-\item{yend}{Unquoted yend aesthetic variable.}
+\item{yend}{Unquoted \code{yend} aesthetic variable.}
 
-\item{z}{Unquoted z aesthetic variable.}
+\item{z}{Unquoted \code{z} aesthetic variable.}
 
-\item{col}{Unquoted col and fill aesthetic variable.}
+\item{col}{Unquoted \code{col} and \code{fill} aesthetic variable.}
 
-\item{alpha}{Unquoted alpha aesthetic variable.}
+\item{alpha}{Unquoted \code{alpha} aesthetic variable.}
 
-\item{facet}{Unquoted facet aesthetic variable.}
+\item{facet}{Unquoted \code{facet} aesthetic variable.}
 
 \item{facet2}{Unquoted second facet variable.}
 
-\item{group}{Unquoted group aesthetic variable.}
+\item{group}{Unquoted \code{group} aesthetic variable.}
 
-\item{subgroup}{Unquoted subgroup aesthetic variable.}
+\item{subgroup}{Unquoted \code{subgroup} aesthetic variable.}
 
-\item{label}{Unquoted label aesthetic variable.}
+\item{label}{Unquoted \code{label} aesthetic variable.}
 
-\item{text}{Unquoted text aesthetic variable.}
+\item{text}{Unquoted \code{text} aesthetic variable.}
 
-\item{sample}{Unquoted sample aesthetic variable.}
+\item{sample}{Unquoted \code{sample} aesthetic variable.}
 
-\item{mapping}{Set of additional aesthetic mappings within the ggplot2::aes function for non-supported aesthetics (e.g. shape, linetype, linewidth, or size) or for delayed evaluation.}
+\item{mapping}{Set of additional aesthetic mappings within \code{ggplot2::aes()} for non-supported aesthetics (e.g. \code{shape}, \code{linetype}, \code{linewidth}, or \code{size}) or for delayed evaluation.}
 
-\item{x_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{x_breaks, y_breaks}{A \verb{scales::breaks_*} function (e.g. \code{\link[scales:breaks_pretty]{scales::breaks_pretty()}}), or a vector of breaks.}
 
-\item{x_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{x_expand, y_expand}{Padding to the limits with the \code{ggplot2::expansion()} function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{x_expand_limits}{For a continuous x variable, any values that the limits should encompass (e.g. 0).}
+\item{x_expand_limits, y_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{x_gridlines}{TRUE or FALSE for vertical x gridlines. NULL guesses based on the classes of the x and y.}
+\item{x_gridlines}{\code{TRUE} or \code{FALSE} for vertical \code{x} gridlines. \code{NULL} guesses based on the classes of the x and y.}
 
-\item{x_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{x_labels, y_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{\link[scales:label_number]{scales::label_comma()}}), or a vector of labels.}
 
-\item{x_limits}{A vector of length 2 to determine the limits of the axis.}
+\item{x_limits, y_limits}{A vector of length 2 to determine the limits of the axis.}
 
-\item{x_oob}{For a continuous x variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{x_oob, y_oob}{For a continuous \code{x} variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
-\item{x_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
+\item{x_sec_axis, y_sec_axis}{A secondary axis using \code{ggplot2::sec_axis()} or \code{ggplot2::dup_axis()}.}
 
-\item{x_title}{Axis title string. Use "" for no title.}
+\item{x_title, y_title}{Axis title string. Use \code{""} for no title.}
 
-\item{x_transform}{For a numeric x variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{x_transform, y_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{y_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{y_gridlines}{\code{TRUE} or \code{FALSE} of horizontal \code{y} gridlines. \code{NULL} guesses based on the classes of the \code{x} and \code{y}.}
 
-\item{y_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
-
-\item{y_expand_limits}{For a continuous y variable, any values that the limits should encompass (e.g. 0).}
-
-\item{y_gridlines}{TRUE or FALSE of horizontal y gridlines. NULL guesses based on the classes of the x and y.}
-
-\item{y_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
-
-\item{y_limits}{A vector of length 2 to determine the limits of the axis.}
-
-\item{y_oob}{For a continuous y variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
-
-\item{y_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
-
-\item{y_title}{Axis title string. Use "" for no title.}
-
-\item{y_transform}{For a numeric y variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
-
-\item{col_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{col_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{col_continuous_type}{For a continuous variable, whether to colour as a "gradient" or in "steps". Defaults to "gradient".}
 
 \item{col_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{col_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{col_expand}{Padding to the limits with \code{ggplot2::expansion()}, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{col_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{col_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{col_legend_ncol}{The number of columns for the legend elements.}
+\item{col_legend_ncol, col_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{col_legend_nrow}{The number of rows for the legend elements.}
-
-\item{col_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{col_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{col_limits}{A vector to determine the limits of the scale.}
 
-\item{col_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{col_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{col_pal}{colours to use. A character vector of hex codes (or names).}
 
-\item{col_pal_na}{colour to use for NA values. A character vector of a hex code (or name).}
+\item{col_pal_na}{colour to use for \code{NA} values. A character vector of a hex code (or name).}
 
-\item{col_rescale}{For a continuous variable, a scales::rescale function.}
+\item{col_rescale}{For a continuous variable, a \code{scales::rescale} function.}
 
 \item{col_title}{Legend title string. Use "" for no title.}
 
-\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{alpha_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{alpha_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{alpha_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{alpha_legend_ncol}{The number of columns for the legend elements.}
+\item{alpha_legend_ncol, alpha_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{alpha_legend_nrow}{The number of rows for the legend elements.}
-
-\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{alpha_limits}{A vector to determine the limits of the scale.}
 
-\item{alpha_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{alpha_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{alpha_pal}{Alpha values to use as a numeric vector. For a continuous variable, a range is only needed.}
 
-\item{alpha_pal_na}{Alpha value to use for the NA value.}
+\item{alpha_pal_na}{Alpha value to use for the \code{NA} value.}
 
-\item{alpha_title}{Legend title string. Use "" for no title.}
+\item{alpha_title}{Legend title string. Use \code{""} for no title.}
 
-\item{alpha_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{alpha_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the transform_ prefix (e.g. "log10").}
 
 \item{facet_axes}{Whether to add interior axes and ticks with "margins", "all", "all_x", or "all_y".}
 
 \item{facet_axis_labels}{Whether to add interior axis labels with "margins", "all", "all_x", or "all_y".}
 
-\item{facet_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
+\item{facet_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
 
 \item{facet_labels_position}{When the facet layout is "wrap", the position of the facet labels. Either "top", "right", "bottom" or "left".}
 
 \item{facet_labels_switch}{When the facet layout is "grid", whether to switch the facet labels to the opposite side of the plot. Either "x", "y" or "both".}
 
-\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If NULL and a single facet (or facet2) argument is provided, then defaults to "wrap". If NULL and both facet and facet2 arguments are provided, defaults to "grid".}
+\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If \code{NULL} and a single \code{facet} (or \code{facet2}) argument is provided, then defaults to "wrap". If \code{NULL} and both facet and facet2 arguments are provided, defaults to "grid".}
 
 \item{facet_ncol}{The number of columns of facets. Only applies to a facet layout of "wrap".}
 
@@ -268,15 +246,15 @@ gg_area(
 
 \item{caption}{Caption title string.}
 
-\item{titles}{A function to format unspecified titles. Defaults to snakecase::to_sentence_case.}
+\item{titles}{A function to format unspecified titles. Defaults to \code{snakecase::to_sentence_case}.}
 
-\item{flipped}{TRUE or FALSE or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
+\item{flipped}{\code{TRUE} or \code{FALSE} or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
 }
 \value{
 A ggplot object.
 }
 \description{
-Create an area ggplot with a wrapper around ggplot() + geom_area.
+Create an area ggplot with a wrapper around \code{ggplot()} + \link[ggplot2:geom_ribbon]{geom_area()}.
 }
 \examples{
 

--- a/man/gg_bar.Rd
+++ b/man/gg_bar.Rd
@@ -98,161 +98,139 @@ gg_bar(
 \arguments{
 \item{data}{A data frame or tibble.}
 
-\item{...}{Other arguments passed to within a params list in the layer function.}
+\item{...}{Other arguments passed to within a \code{params} list in \code{layer()}.}
 
 \item{stat}{A statistical transformation to use on the data. A snakecase character string of a ggproto Stat subclass object minus the Stat prefix (e.g. "identity").}
 
-\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a position_* function that outputs a ggproto Position subclass object (e.g. ggplot2::position_identity()).}
+\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a \verb{position_*()} function that outputs a ggproto Position subclass object (e.g. \code{ggplot2::position_identity()}).}
 
-\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. ggplot2::coord_cartesian()).}
+\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. \code{\link[ggplot2:coord_cartesian]{ggplot2::coord_cartesian()}}).}
 
-\item{theme}{A ggplot2 theme (e.g. light_mode_b(), dark_mode_rt() or ggplot2::theme_grey()).}
+\item{theme}{A ggplot2 theme (e.g. \code{\link[=light_mode_b]{light_mode_b()}}, \code{\link[=dark_mode_rt]{dark_mode_rt()}} or \code{\link[ggplot2:ggtheme]{ggplot2::theme_grey()}}).}
 
-\item{x}{Unquoted x aesthetic variable.}
+\item{x}{Unquoted \code{x} aesthetic variable.}
 
-\item{xmin}{Unquoted xmin aesthetic variable.}
+\item{xmin}{Unquoted \code{xmin} aesthetic variable.}
 
-\item{xmax}{Unquoted xmax aesthetic variable.}
+\item{xmax}{Unquoted \code{xmax} aesthetic variable.}
 
-\item{xend}{Unquoted xend aesthetic variable.}
+\item{xend}{Unquoted \code{xend} aesthetic variable.}
 
-\item{y}{Unquoted y aesthetic variable.}
+\item{y}{Unquoted \code{y} aesthetic variable.}
 
-\item{ymin}{Unquoted ymin aesthetic variable.}
+\item{ymin}{Unquoted \code{ymin} aesthetic variable.}
 
-\item{ymax}{Unquoted ymax aesthetic variable.}
+\item{ymax}{Unquoted \code{ymax} aesthetic variable.}
 
-\item{yend}{Unquoted yend aesthetic variable.}
+\item{yend}{Unquoted \code{yend} aesthetic variable.}
 
-\item{z}{Unquoted z aesthetic variable.}
+\item{z}{Unquoted \code{z} aesthetic variable.}
 
-\item{col}{Unquoted col and fill aesthetic variable.}
+\item{col}{Unquoted \code{col} and \code{fill} aesthetic variable.}
 
-\item{alpha}{Unquoted alpha aesthetic variable.}
+\item{alpha}{Unquoted \code{alpha} aesthetic variable.}
 
-\item{facet}{Unquoted facet aesthetic variable.}
+\item{facet}{Unquoted \code{facet} aesthetic variable.}
 
 \item{facet2}{Unquoted second facet variable.}
 
-\item{group}{Unquoted group aesthetic variable.}
+\item{group}{Unquoted \code{group} aesthetic variable.}
 
-\item{subgroup}{Unquoted subgroup aesthetic variable.}
+\item{subgroup}{Unquoted \code{subgroup} aesthetic variable.}
 
-\item{label}{Unquoted label aesthetic variable.}
+\item{label}{Unquoted \code{label} aesthetic variable.}
 
-\item{text}{Unquoted text aesthetic variable.}
+\item{text}{Unquoted \code{text} aesthetic variable.}
 
-\item{sample}{Unquoted sample aesthetic variable.}
+\item{sample}{Unquoted \code{sample} aesthetic variable.}
 
-\item{mapping}{Set of additional aesthetic mappings within the ggplot2::aes function for non-supported aesthetics (e.g. shape, linetype, linewidth, or size) or for delayed evaluation.}
+\item{mapping}{Set of additional aesthetic mappings within \code{ggplot2::aes()} for non-supported aesthetics (e.g. \code{shape}, \code{linetype}, \code{linewidth}, or \code{size}) or for delayed evaluation.}
 
-\item{x_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{x_breaks, y_breaks}{A \verb{scales::breaks_*} function (e.g. \code{\link[scales:breaks_pretty]{scales::breaks_pretty()}}), or a vector of breaks.}
 
-\item{x_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{x_expand, y_expand}{Padding to the limits with the \code{ggplot2::expansion()} function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{x_expand_limits}{For a continuous x variable, any values that the limits should encompass (e.g. 0).}
+\item{x_expand_limits, y_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{x_gridlines}{TRUE or FALSE for vertical x gridlines. NULL guesses based on the classes of the x and y.}
+\item{x_gridlines}{\code{TRUE} or \code{FALSE} for vertical \code{x} gridlines. \code{NULL} guesses based on the classes of the x and y.}
 
-\item{x_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{x_labels, y_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{\link[scales:label_number]{scales::label_comma()}}), or a vector of labels.}
 
-\item{x_limits}{A vector of length 2 to determine the limits of the axis.}
+\item{x_limits, y_limits}{A vector of length 2 to determine the limits of the axis.}
 
-\item{x_oob}{For a continuous x variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{x_oob, y_oob}{For a continuous \code{x} variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
-\item{x_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
+\item{x_sec_axis, y_sec_axis}{A secondary axis using \code{ggplot2::sec_axis()} or \code{ggplot2::dup_axis()}.}
 
-\item{x_title}{Axis title string. Use "" for no title.}
+\item{x_title, y_title}{Axis title string. Use \code{""} for no title.}
 
-\item{x_transform}{For a numeric x variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{x_transform, y_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{y_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{y_gridlines}{\code{TRUE} or \code{FALSE} of horizontal \code{y} gridlines. \code{NULL} guesses based on the classes of the \code{x} and \code{y}.}
 
-\item{y_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
-
-\item{y_expand_limits}{For a continuous y variable, any values that the limits should encompass (e.g. 0).}
-
-\item{y_gridlines}{TRUE or FALSE of horizontal y gridlines. NULL guesses based on the classes of the x and y.}
-
-\item{y_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
-
-\item{y_limits}{A vector of length 2 to determine the limits of the axis.}
-
-\item{y_oob}{For a continuous y variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
-
-\item{y_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
-
-\item{y_title}{Axis title string. Use "" for no title.}
-
-\item{y_transform}{For a numeric y variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
-
-\item{col_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{col_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{col_continuous_type}{For a continuous variable, whether to colour as a "gradient" or in "steps". Defaults to "gradient".}
 
 \item{col_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{col_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{col_expand}{Padding to the limits with \code{ggplot2::expansion()}, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{col_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{col_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{col_legend_ncol}{The number of columns for the legend elements.}
+\item{col_legend_ncol, col_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{col_legend_nrow}{The number of rows for the legend elements.}
-
-\item{col_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{col_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{col_limits}{A vector to determine the limits of the scale.}
 
-\item{col_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{col_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{col_pal}{colours to use. A character vector of hex codes (or names).}
 
-\item{col_pal_na}{colour to use for NA values. A character vector of a hex code (or name).}
+\item{col_pal_na}{colour to use for \code{NA} values. A character vector of a hex code (or name).}
 
-\item{col_rescale}{For a continuous variable, a scales::rescale function.}
+\item{col_rescale}{For a continuous variable, a \code{scales::rescale} function.}
 
 \item{col_title}{Legend title string. Use "" for no title.}
 
-\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{alpha_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{alpha_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{alpha_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{alpha_legend_ncol}{The number of columns for the legend elements.}
+\item{alpha_legend_ncol, alpha_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{alpha_legend_nrow}{The number of rows for the legend elements.}
-
-\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{alpha_limits}{A vector to determine the limits of the scale.}
 
-\item{alpha_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{alpha_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{alpha_pal}{Alpha values to use as a numeric vector. For a continuous variable, a range is only needed.}
 
-\item{alpha_pal_na}{Alpha value to use for the NA value.}
+\item{alpha_pal_na}{Alpha value to use for the \code{NA} value.}
 
-\item{alpha_title}{Legend title string. Use "" for no title.}
+\item{alpha_title}{Legend title string. Use \code{""} for no title.}
 
-\item{alpha_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{alpha_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the transform_ prefix (e.g. "log10").}
 
 \item{facet_axes}{Whether to add interior axes and ticks with "margins", "all", "all_x", or "all_y".}
 
 \item{facet_axis_labels}{Whether to add interior axis labels with "margins", "all", "all_x", or "all_y".}
 
-\item{facet_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
+\item{facet_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
 
 \item{facet_labels_position}{When the facet layout is "wrap", the position of the facet labels. Either "top", "right", "bottom" or "left".}
 
 \item{facet_labels_switch}{When the facet layout is "grid", whether to switch the facet labels to the opposite side of the plot. Either "x", "y" or "both".}
 
-\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If NULL and a single facet (or facet2) argument is provided, then defaults to "wrap". If NULL and both facet and facet2 arguments are provided, defaults to "grid".}
+\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If \code{NULL} and a single \code{facet} (or \code{facet2}) argument is provided, then defaults to "wrap". If \code{NULL} and both facet and facet2 arguments are provided, defaults to "grid".}
 
 \item{facet_ncol}{The number of columns of facets. Only applies to a facet layout of "wrap".}
 
@@ -268,15 +246,15 @@ gg_bar(
 
 \item{caption}{Caption title string.}
 
-\item{titles}{A function to format unspecified titles. Defaults to snakecase::to_sentence_case.}
+\item{titles}{A function to format unspecified titles. Defaults to \code{snakecase::to_sentence_case}.}
 
-\item{flipped}{TRUE or FALSE or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
+\item{flipped}{\code{TRUE} or \code{FALSE} or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
 }
 \value{
 A ggplot object.
 }
 \description{
-Create a bar ggplot with a wrapper around ggplot() + geom_bar.
+Create a bar ggplot with a wrapper around \code{ggplot()} + \link[ggplot2:geom_bar]{geom_bar()}.
 }
 \examples{
 

--- a/man/gg_bin_2d.Rd
+++ b/man/gg_bin_2d.Rd
@@ -98,161 +98,139 @@ gg_bin_2d(
 \arguments{
 \item{data}{A data frame or tibble.}
 
-\item{...}{Other arguments passed to within a params list in the layer function.}
+\item{...}{Other arguments passed to within a \code{params} list in \code{layer()}.}
 
 \item{stat}{A statistical transformation to use on the data. A snakecase character string of a ggproto Stat subclass object minus the Stat prefix (e.g. "identity").}
 
-\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a position_* function that outputs a ggproto Position subclass object (e.g. ggplot2::position_identity()).}
+\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a \verb{position_*()} function that outputs a ggproto Position subclass object (e.g. \code{ggplot2::position_identity()}).}
 
-\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. ggplot2::coord_cartesian()).}
+\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. \code{\link[ggplot2:coord_cartesian]{ggplot2::coord_cartesian()}}).}
 
-\item{theme}{A ggplot2 theme (e.g. light_mode_b(), dark_mode_rt() or ggplot2::theme_grey()).}
+\item{theme}{A ggplot2 theme (e.g. \code{\link[=light_mode_b]{light_mode_b()}}, \code{\link[=dark_mode_rt]{dark_mode_rt()}} or \code{\link[ggplot2:ggtheme]{ggplot2::theme_grey()}}).}
 
-\item{x}{Unquoted x aesthetic variable.}
+\item{x}{Unquoted \code{x} aesthetic variable.}
 
-\item{xmin}{Unquoted xmin aesthetic variable.}
+\item{xmin}{Unquoted \code{xmin} aesthetic variable.}
 
-\item{xmax}{Unquoted xmax aesthetic variable.}
+\item{xmax}{Unquoted \code{xmax} aesthetic variable.}
 
-\item{xend}{Unquoted xend aesthetic variable.}
+\item{xend}{Unquoted \code{xend} aesthetic variable.}
 
-\item{y}{Unquoted y aesthetic variable.}
+\item{y}{Unquoted \code{y} aesthetic variable.}
 
-\item{ymin}{Unquoted ymin aesthetic variable.}
+\item{ymin}{Unquoted \code{ymin} aesthetic variable.}
 
-\item{ymax}{Unquoted ymax aesthetic variable.}
+\item{ymax}{Unquoted \code{ymax} aesthetic variable.}
 
-\item{yend}{Unquoted yend aesthetic variable.}
+\item{yend}{Unquoted \code{yend} aesthetic variable.}
 
-\item{z}{Unquoted z aesthetic variable.}
+\item{z}{Unquoted \code{z} aesthetic variable.}
 
-\item{col}{Unquoted col and fill aesthetic variable.}
+\item{col}{Unquoted \code{col} and \code{fill} aesthetic variable.}
 
-\item{alpha}{Unquoted alpha aesthetic variable.}
+\item{alpha}{Unquoted \code{alpha} aesthetic variable.}
 
-\item{facet}{Unquoted facet aesthetic variable.}
+\item{facet}{Unquoted \code{facet} aesthetic variable.}
 
 \item{facet2}{Unquoted second facet variable.}
 
-\item{group}{Unquoted group aesthetic variable.}
+\item{group}{Unquoted \code{group} aesthetic variable.}
 
-\item{subgroup}{Unquoted subgroup aesthetic variable.}
+\item{subgroup}{Unquoted \code{subgroup} aesthetic variable.}
 
-\item{label}{Unquoted label aesthetic variable.}
+\item{label}{Unquoted \code{label} aesthetic variable.}
 
-\item{text}{Unquoted text aesthetic variable.}
+\item{text}{Unquoted \code{text} aesthetic variable.}
 
-\item{sample}{Unquoted sample aesthetic variable.}
+\item{sample}{Unquoted \code{sample} aesthetic variable.}
 
-\item{mapping}{Set of additional aesthetic mappings within the ggplot2::aes function for non-supported aesthetics (e.g. shape, linetype, linewidth, or size) or for delayed evaluation.}
+\item{mapping}{Set of additional aesthetic mappings within \code{ggplot2::aes()} for non-supported aesthetics (e.g. \code{shape}, \code{linetype}, \code{linewidth}, or \code{size}) or for delayed evaluation.}
 
-\item{x_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{x_breaks, y_breaks}{A \verb{scales::breaks_*} function (e.g. \code{\link[scales:breaks_pretty]{scales::breaks_pretty()}}), or a vector of breaks.}
 
-\item{x_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{x_expand, y_expand}{Padding to the limits with the \code{ggplot2::expansion()} function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{x_expand_limits}{For a continuous x variable, any values that the limits should encompass (e.g. 0).}
+\item{x_expand_limits, y_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{x_gridlines}{TRUE or FALSE for vertical x gridlines. NULL guesses based on the classes of the x and y.}
+\item{x_gridlines}{\code{TRUE} or \code{FALSE} for vertical \code{x} gridlines. \code{NULL} guesses based on the classes of the x and y.}
 
-\item{x_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{x_labels, y_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{\link[scales:label_number]{scales::label_comma()}}), or a vector of labels.}
 
-\item{x_limits}{A vector of length 2 to determine the limits of the axis.}
+\item{x_limits, y_limits}{A vector of length 2 to determine the limits of the axis.}
 
-\item{x_oob}{For a continuous x variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{x_oob, y_oob}{For a continuous \code{x} variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
-\item{x_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
+\item{x_sec_axis, y_sec_axis}{A secondary axis using \code{ggplot2::sec_axis()} or \code{ggplot2::dup_axis()}.}
 
-\item{x_title}{Axis title string. Use "" for no title.}
+\item{x_title, y_title}{Axis title string. Use \code{""} for no title.}
 
-\item{x_transform}{For a numeric x variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{x_transform, y_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{y_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{y_gridlines}{\code{TRUE} or \code{FALSE} of horizontal \code{y} gridlines. \code{NULL} guesses based on the classes of the \code{x} and \code{y}.}
 
-\item{y_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
-
-\item{y_expand_limits}{For a continuous y variable, any values that the limits should encompass (e.g. 0).}
-
-\item{y_gridlines}{TRUE or FALSE of horizontal y gridlines. NULL guesses based on the classes of the x and y.}
-
-\item{y_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
-
-\item{y_limits}{A vector of length 2 to determine the limits of the axis.}
-
-\item{y_oob}{For a continuous y variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
-
-\item{y_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
-
-\item{y_title}{Axis title string. Use "" for no title.}
-
-\item{y_transform}{For a numeric y variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
-
-\item{col_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{col_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{col_continuous_type}{For a continuous variable, whether to colour as a "gradient" or in "steps". Defaults to "gradient".}
 
 \item{col_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{col_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{col_expand}{Padding to the limits with \code{ggplot2::expansion()}, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{col_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{col_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{col_legend_ncol}{The number of columns for the legend elements.}
+\item{col_legend_ncol, col_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{col_legend_nrow}{The number of rows for the legend elements.}
-
-\item{col_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{col_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{col_limits}{A vector to determine the limits of the scale.}
 
-\item{col_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{col_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{col_pal}{colours to use. A character vector of hex codes (or names).}
 
-\item{col_pal_na}{colour to use for NA values. A character vector of a hex code (or name).}
+\item{col_pal_na}{colour to use for \code{NA} values. A character vector of a hex code (or name).}
 
-\item{col_rescale}{For a continuous variable, a scales::rescale function.}
+\item{col_rescale}{For a continuous variable, a \code{scales::rescale} function.}
 
 \item{col_title}{Legend title string. Use "" for no title.}
 
-\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{alpha_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{alpha_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{alpha_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{alpha_legend_ncol}{The number of columns for the legend elements.}
+\item{alpha_legend_ncol, alpha_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{alpha_legend_nrow}{The number of rows for the legend elements.}
-
-\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{alpha_limits}{A vector to determine the limits of the scale.}
 
-\item{alpha_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{alpha_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{alpha_pal}{Alpha values to use as a numeric vector. For a continuous variable, a range is only needed.}
 
-\item{alpha_pal_na}{Alpha value to use for the NA value.}
+\item{alpha_pal_na}{Alpha value to use for the \code{NA} value.}
 
-\item{alpha_title}{Legend title string. Use "" for no title.}
+\item{alpha_title}{Legend title string. Use \code{""} for no title.}
 
-\item{alpha_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{alpha_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the transform_ prefix (e.g. "log10").}
 
 \item{facet_axes}{Whether to add interior axes and ticks with "margins", "all", "all_x", or "all_y".}
 
 \item{facet_axis_labels}{Whether to add interior axis labels with "margins", "all", "all_x", or "all_y".}
 
-\item{facet_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
+\item{facet_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
 
 \item{facet_labels_position}{When the facet layout is "wrap", the position of the facet labels. Either "top", "right", "bottom" or "left".}
 
 \item{facet_labels_switch}{When the facet layout is "grid", whether to switch the facet labels to the opposite side of the plot. Either "x", "y" or "both".}
 
-\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If NULL and a single facet (or facet2) argument is provided, then defaults to "wrap". If NULL and both facet and facet2 arguments are provided, defaults to "grid".}
+\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If \code{NULL} and a single \code{facet} (or \code{facet2}) argument is provided, then defaults to "wrap". If \code{NULL} and both facet and facet2 arguments are provided, defaults to "grid".}
 
 \item{facet_ncol}{The number of columns of facets. Only applies to a facet layout of "wrap".}
 
@@ -268,15 +246,15 @@ gg_bin_2d(
 
 \item{caption}{Caption title string.}
 
-\item{titles}{A function to format unspecified titles. Defaults to snakecase::to_sentence_case.}
+\item{titles}{A function to format unspecified titles. Defaults to \code{snakecase::to_sentence_case}.}
 
-\item{flipped}{TRUE or FALSE or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
+\item{flipped}{\code{TRUE} or \code{FALSE} or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
 }
 \value{
 A ggplot object.
 }
 \description{
-Create a bin2d ggplot with a wrapper around ggplot() + geom_bin_2d.
+Create a bin2d ggplot with a wrapper around \code{ggplot()} + \link[ggplot2:geom_bin_2d]{geom_bin_2d()}.
 }
 \examples{
 

--- a/man/gg_blanket.Rd
+++ b/man/gg_blanket.Rd
@@ -99,137 +99,117 @@ gg_blanket(
 \arguments{
 \item{data}{A data frame or tibble.}
 
-\item{...}{Other arguments passed to within a params list in the layer function.}
+\item{...}{Other arguments passed to within a \code{params} list in \code{layer()}.}
 
 \item{geom}{A geometric object to display the data. A snakecase character string of a ggproto Geom subclass object minus the Geom prefix (e.g. "point").}
 
 \item{stat}{A statistical transformation to use on the data. A snakecase character string of a ggproto Stat subclass object minus the Stat prefix (e.g. "identity").}
 
-\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a position_* function that outputs a ggproto Position subclass object (e.g. ggplot2::position_identity()).}
+\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a \verb{position_*()} function that outputs a ggproto Position subclass object (e.g. \code{ggplot2::position_identity()}).}
 
-\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. ggplot2::coord_cartesian()).}
+\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. \code{\link[ggplot2:coord_cartesian]{ggplot2::coord_cartesian()}}).}
 
-\item{theme}{A ggplot2 theme (e.g. light_mode_b(), dark_mode_rt() or ggplot2::theme_grey()).}
+\item{theme}{A ggplot2 theme (e.g. \code{\link[=light_mode_b]{light_mode_b()}}, \code{\link[=dark_mode_rt]{dark_mode_rt()}} or \code{\link[ggplot2:ggtheme]{ggplot2::theme_grey()}}).}
 
-\item{x}{Unquoted x aesthetic variable.}
+\item{x}{Unquoted \code{x} aesthetic variable.}
 
-\item{xmin}{Unquoted xmin aesthetic variable.}
+\item{xmin}{Unquoted \code{xmin} aesthetic variable.}
 
-\item{xmax}{Unquoted xmax aesthetic variable.}
+\item{xmax}{Unquoted \code{xmax} aesthetic variable.}
 
-\item{xend}{Unquoted xend aesthetic variable.}
+\item{xend}{Unquoted \code{xend} aesthetic variable.}
 
-\item{y}{Unquoted y aesthetic variable.}
+\item{y}{Unquoted \code{y} aesthetic variable.}
 
-\item{ymin}{Unquoted ymin aesthetic variable.}
+\item{ymin}{Unquoted \code{ymin} aesthetic variable.}
 
-\item{ymax}{Unquoted ymax aesthetic variable.}
+\item{ymax}{Unquoted \code{ymax} aesthetic variable.}
 
-\item{yend}{Unquoted yend aesthetic variable.}
+\item{yend}{Unquoted \code{yend} aesthetic variable.}
 
-\item{z}{Unquoted z aesthetic variable.}
+\item{z}{Unquoted \code{z} aesthetic variable.}
 
-\item{col}{Unquoted col and fill aesthetic variable.}
+\item{col}{Unquoted \code{col} and \code{fill} aesthetic variable.}
 
-\item{alpha}{Unquoted alpha aesthetic variable.}
+\item{alpha}{Unquoted \code{alpha} aesthetic variable.}
 
-\item{facet}{Unquoted facet aesthetic variable.}
+\item{facet}{Unquoted \code{facet} aesthetic variable.}
 
 \item{facet2}{Unquoted second facet variable.}
 
-\item{group}{Unquoted group aesthetic variable.}
+\item{group}{Unquoted \code{group} aesthetic variable.}
 
-\item{subgroup}{Unquoted subgroup aesthetic variable.}
+\item{subgroup}{Unquoted \code{subgroup} aesthetic variable.}
 
-\item{label}{Unquoted label aesthetic variable.}
+\item{label}{Unquoted \code{label} aesthetic variable.}
 
-\item{text}{Unquoted text aesthetic variable.}
+\item{text}{Unquoted \code{text} aesthetic variable.}
 
-\item{sample}{Unquoted sample aesthetic variable.}
+\item{sample}{Unquoted \code{sample} aesthetic variable.}
 
-\item{mapping}{Set of additional aesthetic mappings within the ggplot2::aes function for non-supported aesthetics (e.g. shape, linetype, linewidth, or size) or for delayed evaluation.}
+\item{mapping}{Set of additional aesthetic mappings within \code{ggplot2::aes()} for non-supported aesthetics (e.g. \code{shape}, \code{linetype}, \code{linewidth}, or \code{size}) or for delayed evaluation.}
 
-\item{x_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{x_breaks, y_breaks}{A \verb{scales::breaks_*} function (e.g. \code{\link[scales:breaks_pretty]{scales::breaks_pretty()}}), or a vector of breaks.}
 
-\item{x_gridlines}{TRUE or FALSE for vertical x gridlines. NULL guesses based on the classes of the x and y.}
+\item{x_gridlines}{\code{TRUE} or \code{FALSE} for vertical \code{x} gridlines. \code{NULL} guesses based on the classes of the x and y.}
 
-\item{x_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{x_expand, y_expand}{Padding to the limits with the \code{ggplot2::expansion()} function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{x_expand_limits}{For a continuous x variable, any values that the limits should encompass (e.g. 0).}
+\item{x_expand_limits, y_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{x_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{x_labels, y_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{\link[scales:label_number]{scales::label_comma()}}), or a vector of labels.}
 
-\item{x_limits}{A vector of length 2 to determine the limits of the axis.}
+\item{x_limits, y_limits}{A vector of length 2 to determine the limits of the axis.}
 
-\item{x_oob}{For a continuous x variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{x_oob, y_oob}{For a continuous \code{x} variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
-\item{x_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
+\item{x_sec_axis, y_sec_axis}{A secondary axis using \code{ggplot2::sec_axis()} or \code{ggplot2::dup_axis()}.}
 
-\item{x_title}{Axis title string. Use "" for no title.}
+\item{x_title, y_title}{Axis title string. Use \code{""} for no title.}
 
-\item{x_transform}{For a numeric x variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{x_transform, y_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{y_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{y_gridlines}{\code{TRUE} or \code{FALSE} of horizontal \code{y} gridlines. \code{NULL} guesses based on the classes of the \code{x} and \code{y}.}
 
-\item{y_gridlines}{TRUE or FALSE of horizontal y gridlines. NULL guesses based on the classes of the x and y.}
-
-\item{y_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
-
-\item{y_expand_limits}{For a continuous y variable, any values that the limits should encompass (e.g. 0).}
-
-\item{y_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
-
-\item{y_limits}{A vector of length 2 to determine the limits of the axis.}
-
-\item{y_oob}{For a continuous y variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
-
-\item{y_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
-
-\item{y_title}{Axis title string. Use "" for no title.}
-
-\item{y_transform}{For a numeric y variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
-
-\item{col_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{col_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{col_continuous_type}{For a continuous variable, whether to colour as a "gradient" or in "steps". Defaults to "gradient".}
 
-\item{col_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{col_expand}{Padding to the limits with \code{ggplot2::expansion()}, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
 \item{col_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{col_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{col_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{col_legend_ncol}{The number of columns for the legend elements.}
+\item{col_legend_ncol, col_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{col_legend_nrow}{The number of rows for the legend elements.}
-
-\item{col_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{col_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{col_limits}{A vector to determine the limits of the scale.}
 
-\item{col_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{col_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{col_pal}{colours to use. A character vector of hex codes (or names).}
 
-\item{col_pal_na}{colour to use for NA values. A character vector of a hex code (or name).}
+\item{col_pal_na}{colour to use for \code{NA} values. A character vector of a hex code (or name).}
 
-\item{col_rescale}{For a continuous variable, a scales::rescale function.}
+\item{col_rescale}{For a continuous variable, a \code{scales::rescale} function.}
 
 \item{col_title}{Legend title string. Use "" for no title.}
 
-\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
 \item{facet_axes}{Whether to add interior axes and ticks with "margins", "all", "all_x", or "all_y".}
 
 \item{facet_axis_labels}{Whether to add interior axis labels with "margins", "all", "all_x", or "all_y".}
 
-\item{facet_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
+\item{facet_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
 
 \item{facet_labels_position}{When the facet layout is "wrap", the position of the facet labels. Either "top", "right", "bottom" or "left".}
 
 \item{facet_labels_switch}{When the facet layout is "grid", whether to switch the facet labels to the opposite side of the plot. Either "x", "y" or "both".}
 
-\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If NULL and a single facet (or facet2) argument is provided, then defaults to "wrap". If NULL and both facet and facet2 arguments are provided, defaults to "grid".}
+\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If \code{NULL} and a single \code{facet} (or \code{facet2}) argument is provided, then defaults to "wrap". If \code{NULL} and both facet and facet2 arguments are provided, defaults to "grid".}
 
 \item{facet_ncol}{The number of columns of facets. Only applies to a facet layout of "wrap".}
 
@@ -239,31 +219,29 @@ gg_blanket(
 
 \item{facet_space}{When the facet layout is "grid" and facet scales are not "fixed", whether facet space should be "fixed" across facets, "free" to be proportional in both directions, or free to be proportional in just one direction (i.e. "free_x" or "free_y"). Defaults to "fixed".}
 
-\item{alpha_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{alpha_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
-\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
 \item{alpha_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{alpha_legend_ncol}{The number of columns for the legend elements.}
+\item{alpha_legend_ncol, alpha_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{alpha_legend_nrow}{The number of rows for the legend elements.}
-
-\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{alpha_limits}{A vector to determine the limits of the scale.}
 
-\item{alpha_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{alpha_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{alpha_pal}{Alpha values to use as a numeric vector. For a continuous variable, a range is only needed.}
 
-\item{alpha_pal_na}{Alpha value to use for the NA value.}
+\item{alpha_pal_na}{Alpha value to use for the \code{NA} value.}
 
-\item{alpha_title}{Legend title string. Use "" for no title.}
+\item{alpha_title}{Legend title string. Use \code{""} for no title.}
 
-\item{alpha_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{alpha_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the transform_ prefix (e.g. "log10").}
 
 \item{title}{Title string.}
 
@@ -271,15 +249,15 @@ gg_blanket(
 
 \item{caption}{Caption title string.}
 
-\item{titles}{A function to format unspecified titles. Defaults to snakecase::to_sentence_case.}
+\item{titles}{A function to format unspecified titles. Defaults to \code{snakecase::to_sentence_case}.}
 
-\item{flipped}{TRUE or FALSE or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
+\item{flipped}{\code{TRUE} or \code{FALSE} or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
 }
 \value{
 A ggplot object.
 }
 \description{
-Create a blanket ggplot with a wrapper around ggplot() + layer() with geom_blank defaults.
+Create a blanket ggplot with a wrapper around \code{ggplot()} + \code{layer()} with \link[ggplot2:geom_blank]{geom_blank()} defaults.
 }
 \examples{
 

--- a/man/gg_boxplot.Rd
+++ b/man/gg_boxplot.Rd
@@ -98,161 +98,139 @@ gg_boxplot(
 \arguments{
 \item{data}{A data frame or tibble.}
 
-\item{...}{Other arguments passed to within a params list in the layer function.}
+\item{...}{Other arguments passed to within a \code{params} list in \code{layer()}.}
 
 \item{stat}{A statistical transformation to use on the data. A snakecase character string of a ggproto Stat subclass object minus the Stat prefix (e.g. "identity").}
 
-\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a position_* function that outputs a ggproto Position subclass object (e.g. ggplot2::position_identity()).}
+\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a \verb{position_*()} function that outputs a ggproto Position subclass object (e.g. \code{ggplot2::position_identity()}).}
 
-\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. ggplot2::coord_cartesian()).}
+\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. \code{\link[ggplot2:coord_cartesian]{ggplot2::coord_cartesian()}}).}
 
-\item{theme}{A ggplot2 theme (e.g. light_mode_b(), dark_mode_rt() or ggplot2::theme_grey()).}
+\item{theme}{A ggplot2 theme (e.g. \code{\link[=light_mode_b]{light_mode_b()}}, \code{\link[=dark_mode_rt]{dark_mode_rt()}} or \code{\link[ggplot2:ggtheme]{ggplot2::theme_grey()}}).}
 
-\item{x}{Unquoted x aesthetic variable.}
+\item{x}{Unquoted \code{x} aesthetic variable.}
 
-\item{xmin}{Unquoted xmin aesthetic variable.}
+\item{xmin}{Unquoted \code{xmin} aesthetic variable.}
 
-\item{xmax}{Unquoted xmax aesthetic variable.}
+\item{xmax}{Unquoted \code{xmax} aesthetic variable.}
 
-\item{xend}{Unquoted xend aesthetic variable.}
+\item{xend}{Unquoted \code{xend} aesthetic variable.}
 
-\item{y}{Unquoted y aesthetic variable.}
+\item{y}{Unquoted \code{y} aesthetic variable.}
 
-\item{ymin}{Unquoted ymin aesthetic variable.}
+\item{ymin}{Unquoted \code{ymin} aesthetic variable.}
 
-\item{ymax}{Unquoted ymax aesthetic variable.}
+\item{ymax}{Unquoted \code{ymax} aesthetic variable.}
 
-\item{yend}{Unquoted yend aesthetic variable.}
+\item{yend}{Unquoted \code{yend} aesthetic variable.}
 
-\item{z}{Unquoted z aesthetic variable.}
+\item{z}{Unquoted \code{z} aesthetic variable.}
 
-\item{col}{Unquoted col and fill aesthetic variable.}
+\item{col}{Unquoted \code{col} and \code{fill} aesthetic variable.}
 
-\item{alpha}{Unquoted alpha aesthetic variable.}
+\item{alpha}{Unquoted \code{alpha} aesthetic variable.}
 
-\item{facet}{Unquoted facet aesthetic variable.}
+\item{facet}{Unquoted \code{facet} aesthetic variable.}
 
 \item{facet2}{Unquoted second facet variable.}
 
-\item{group}{Unquoted group aesthetic variable.}
+\item{group}{Unquoted \code{group} aesthetic variable.}
 
-\item{subgroup}{Unquoted subgroup aesthetic variable.}
+\item{subgroup}{Unquoted \code{subgroup} aesthetic variable.}
 
-\item{label}{Unquoted label aesthetic variable.}
+\item{label}{Unquoted \code{label} aesthetic variable.}
 
-\item{text}{Unquoted text aesthetic variable.}
+\item{text}{Unquoted \code{text} aesthetic variable.}
 
-\item{sample}{Unquoted sample aesthetic variable.}
+\item{sample}{Unquoted \code{sample} aesthetic variable.}
 
-\item{mapping}{Set of additional aesthetic mappings within the ggplot2::aes function for non-supported aesthetics (e.g. shape, linetype, linewidth, or size) or for delayed evaluation.}
+\item{mapping}{Set of additional aesthetic mappings within \code{ggplot2::aes()} for non-supported aesthetics (e.g. \code{shape}, \code{linetype}, \code{linewidth}, or \code{size}) or for delayed evaluation.}
 
-\item{x_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{x_breaks, y_breaks}{A \verb{scales::breaks_*} function (e.g. \code{\link[scales:breaks_pretty]{scales::breaks_pretty()}}), or a vector of breaks.}
 
-\item{x_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{x_expand, y_expand}{Padding to the limits with the \code{ggplot2::expansion()} function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{x_expand_limits}{For a continuous x variable, any values that the limits should encompass (e.g. 0).}
+\item{x_expand_limits, y_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{x_gridlines}{TRUE or FALSE for vertical x gridlines. NULL guesses based on the classes of the x and y.}
+\item{x_gridlines}{\code{TRUE} or \code{FALSE} for vertical \code{x} gridlines. \code{NULL} guesses based on the classes of the x and y.}
 
-\item{x_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{x_labels, y_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{\link[scales:label_number]{scales::label_comma()}}), or a vector of labels.}
 
-\item{x_limits}{A vector of length 2 to determine the limits of the axis.}
+\item{x_limits, y_limits}{A vector of length 2 to determine the limits of the axis.}
 
-\item{x_oob}{For a continuous x variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{x_oob, y_oob}{For a continuous \code{x} variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
-\item{x_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
+\item{x_sec_axis, y_sec_axis}{A secondary axis using \code{ggplot2::sec_axis()} or \code{ggplot2::dup_axis()}.}
 
-\item{x_title}{Axis title string. Use "" for no title.}
+\item{x_title, y_title}{Axis title string. Use \code{""} for no title.}
 
-\item{x_transform}{For a numeric x variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{x_transform, y_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{y_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{y_gridlines}{\code{TRUE} or \code{FALSE} of horizontal \code{y} gridlines. \code{NULL} guesses based on the classes of the \code{x} and \code{y}.}
 
-\item{y_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
-
-\item{y_expand_limits}{For a continuous y variable, any values that the limits should encompass (e.g. 0).}
-
-\item{y_gridlines}{TRUE or FALSE of horizontal y gridlines. NULL guesses based on the classes of the x and y.}
-
-\item{y_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
-
-\item{y_limits}{A vector of length 2 to determine the limits of the axis.}
-
-\item{y_oob}{For a continuous y variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
-
-\item{y_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
-
-\item{y_title}{Axis title string. Use "" for no title.}
-
-\item{y_transform}{For a numeric y variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
-
-\item{col_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{col_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{col_continuous_type}{For a continuous variable, whether to colour as a "gradient" or in "steps". Defaults to "gradient".}
 
 \item{col_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{col_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{col_expand}{Padding to the limits with \code{ggplot2::expansion()}, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{col_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{col_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{col_legend_ncol}{The number of columns for the legend elements.}
+\item{col_legend_ncol, col_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{col_legend_nrow}{The number of rows for the legend elements.}
-
-\item{col_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{col_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{col_limits}{A vector to determine the limits of the scale.}
 
-\item{col_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{col_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{col_pal}{colours to use. A character vector of hex codes (or names).}
 
-\item{col_pal_na}{colour to use for NA values. A character vector of a hex code (or name).}
+\item{col_pal_na}{colour to use for \code{NA} values. A character vector of a hex code (or name).}
 
-\item{col_rescale}{For a continuous variable, a scales::rescale function.}
+\item{col_rescale}{For a continuous variable, a \code{scales::rescale} function.}
 
 \item{col_title}{Legend title string. Use "" for no title.}
 
-\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{alpha_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{alpha_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{alpha_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{alpha_legend_ncol}{The number of columns for the legend elements.}
+\item{alpha_legend_ncol, alpha_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{alpha_legend_nrow}{The number of rows for the legend elements.}
-
-\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{alpha_limits}{A vector to determine the limits of the scale.}
 
-\item{alpha_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{alpha_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{alpha_pal}{Alpha values to use as a numeric vector. For a continuous variable, a range is only needed.}
 
-\item{alpha_pal_na}{Alpha value to use for the NA value.}
+\item{alpha_pal_na}{Alpha value to use for the \code{NA} value.}
 
-\item{alpha_title}{Legend title string. Use "" for no title.}
+\item{alpha_title}{Legend title string. Use \code{""} for no title.}
 
-\item{alpha_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{alpha_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the transform_ prefix (e.g. "log10").}
 
 \item{facet_axes}{Whether to add interior axes and ticks with "margins", "all", "all_x", or "all_y".}
 
 \item{facet_axis_labels}{Whether to add interior axis labels with "margins", "all", "all_x", or "all_y".}
 
-\item{facet_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
+\item{facet_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
 
 \item{facet_labels_position}{When the facet layout is "wrap", the position of the facet labels. Either "top", "right", "bottom" or "left".}
 
 \item{facet_labels_switch}{When the facet layout is "grid", whether to switch the facet labels to the opposite side of the plot. Either "x", "y" or "both".}
 
-\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If NULL and a single facet (or facet2) argument is provided, then defaults to "wrap". If NULL and both facet and facet2 arguments are provided, defaults to "grid".}
+\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If \code{NULL} and a single \code{facet} (or \code{facet2}) argument is provided, then defaults to "wrap". If \code{NULL} and both facet and facet2 arguments are provided, defaults to "grid".}
 
 \item{facet_ncol}{The number of columns of facets. Only applies to a facet layout of "wrap".}
 
@@ -268,15 +246,15 @@ gg_boxplot(
 
 \item{caption}{Caption title string.}
 
-\item{titles}{A function to format unspecified titles. Defaults to snakecase::to_sentence_case.}
+\item{titles}{A function to format unspecified titles. Defaults to \code{snakecase::to_sentence_case}.}
 
-\item{flipped}{TRUE or FALSE or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
+\item{flipped}{\code{TRUE} or \code{FALSE} or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
 }
 \value{
 A ggplot object.
 }
 \description{
-Create a boxplot ggplot with a wrapper around ggplot() + geom_boxplot.
+Create a boxplot ggplot with a wrapper around \code{ggplot()} + \link[ggplot2:geom_boxplot]{geom_boxplot()}.
 }
 \examples{
 

--- a/man/gg_col.Rd
+++ b/man/gg_col.Rd
@@ -98,135 +98,115 @@ gg_col(
 \arguments{
 \item{data}{A data frame or tibble.}
 
-\item{...}{Other arguments passed to within a params list in the layer function.}
+\item{...}{Other arguments passed to within a \code{params} list in \code{layer()}.}
 
 \item{stat}{A statistical transformation to use on the data. A snakecase character string of a ggproto Stat subclass object minus the Stat prefix (e.g. "identity").}
 
-\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a position_* function that outputs a ggproto Position subclass object (e.g. ggplot2::position_identity()).}
+\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a \verb{position_*()} function that outputs a ggproto Position subclass object (e.g. \code{ggplot2::position_identity()}).}
 
-\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. ggplot2::coord_cartesian()).}
+\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. \code{\link[ggplot2:coord_cartesian]{ggplot2::coord_cartesian()}}).}
 
-\item{theme}{A ggplot2 theme (e.g. light_mode_b(), dark_mode_rt() or ggplot2::theme_grey()).}
+\item{theme}{A ggplot2 theme (e.g. \code{\link[=light_mode_b]{light_mode_b()}}, \code{\link[=dark_mode_rt]{dark_mode_rt()}} or \code{\link[ggplot2:ggtheme]{ggplot2::theme_grey()}}).}
 
-\item{x}{Unquoted x aesthetic variable.}
+\item{x}{Unquoted \code{x} aesthetic variable.}
 
-\item{xmin}{Unquoted xmin aesthetic variable.}
+\item{xmin}{Unquoted \code{xmin} aesthetic variable.}
 
-\item{xmax}{Unquoted xmax aesthetic variable.}
+\item{xmax}{Unquoted \code{xmax} aesthetic variable.}
 
-\item{xend}{Unquoted xend aesthetic variable.}
+\item{xend}{Unquoted \code{xend} aesthetic variable.}
 
-\item{y}{Unquoted y aesthetic variable.}
+\item{y}{Unquoted \code{y} aesthetic variable.}
 
-\item{ymin}{Unquoted ymin aesthetic variable.}
+\item{ymin}{Unquoted \code{ymin} aesthetic variable.}
 
-\item{ymax}{Unquoted ymax aesthetic variable.}
+\item{ymax}{Unquoted \code{ymax} aesthetic variable.}
 
-\item{yend}{Unquoted yend aesthetic variable.}
+\item{yend}{Unquoted \code{yend} aesthetic variable.}
 
-\item{z}{Unquoted z aesthetic variable.}
+\item{z}{Unquoted \code{z} aesthetic variable.}
 
-\item{col}{Unquoted col and fill aesthetic variable.}
+\item{col}{Unquoted \code{col} and \code{fill} aesthetic variable.}
 
-\item{alpha}{Unquoted alpha aesthetic variable.}
+\item{alpha}{Unquoted \code{alpha} aesthetic variable.}
 
-\item{facet}{Unquoted facet aesthetic variable.}
+\item{facet}{Unquoted \code{facet} aesthetic variable.}
 
 \item{facet2}{Unquoted second facet variable.}
 
-\item{group}{Unquoted group aesthetic variable.}
+\item{group}{Unquoted \code{group} aesthetic variable.}
 
-\item{subgroup}{Unquoted subgroup aesthetic variable.}
+\item{subgroup}{Unquoted \code{subgroup} aesthetic variable.}
 
-\item{label}{Unquoted label aesthetic variable.}
+\item{label}{Unquoted \code{label} aesthetic variable.}
 
-\item{text}{Unquoted text aesthetic variable.}
+\item{text}{Unquoted \code{text} aesthetic variable.}
 
-\item{sample}{Unquoted sample aesthetic variable.}
+\item{sample}{Unquoted \code{sample} aesthetic variable.}
 
-\item{mapping}{Set of additional aesthetic mappings within the ggplot2::aes function for non-supported aesthetics (e.g. shape, linetype, linewidth, or size) or for delayed evaluation.}
+\item{mapping}{Set of additional aesthetic mappings within \code{ggplot2::aes()} for non-supported aesthetics (e.g. \code{shape}, \code{linetype}, \code{linewidth}, or \code{size}) or for delayed evaluation.}
 
-\item{x_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{x_breaks, y_breaks}{A \verb{scales::breaks_*} function (e.g. \code{\link[scales:breaks_pretty]{scales::breaks_pretty()}}), or a vector of breaks.}
 
-\item{x_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{x_expand, y_expand}{Padding to the limits with the \code{ggplot2::expansion()} function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{x_expand_limits}{For a continuous x variable, any values that the limits should encompass (e.g. 0).}
+\item{x_expand_limits, y_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{x_gridlines}{TRUE or FALSE for vertical x gridlines. NULL guesses based on the classes of the x and y.}
+\item{x_gridlines}{\code{TRUE} or \code{FALSE} for vertical \code{x} gridlines. \code{NULL} guesses based on the classes of the x and y.}
 
-\item{x_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{x_labels, y_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{\link[scales:label_number]{scales::label_comma()}}), or a vector of labels.}
 
-\item{x_limits}{A vector of length 2 to determine the limits of the axis.}
+\item{x_limits, y_limits}{A vector of length 2 to determine the limits of the axis.}
 
-\item{x_oob}{For a continuous x variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{x_oob, y_oob}{For a continuous \code{x} variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
-\item{x_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
+\item{x_sec_axis, y_sec_axis}{A secondary axis using \code{ggplot2::sec_axis()} or \code{ggplot2::dup_axis()}.}
 
-\item{x_title}{Axis title string. Use "" for no title.}
+\item{x_title, y_title}{Axis title string. Use \code{""} for no title.}
 
-\item{x_transform}{For a numeric x variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{x_transform, y_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{y_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{y_gridlines}{\code{TRUE} or \code{FALSE} of horizontal \code{y} gridlines. \code{NULL} guesses based on the classes of the \code{x} and \code{y}.}
 
-\item{y_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
-
-\item{y_expand_limits}{For a continuous y variable, any values that the limits should encompass (e.g. 0).}
-
-\item{y_gridlines}{TRUE or FALSE of horizontal y gridlines. NULL guesses based on the classes of the x and y.}
-
-\item{y_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
-
-\item{y_limits}{A vector of length 2 to determine the limits of the axis.}
-
-\item{y_oob}{For a continuous y variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
-
-\item{y_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
-
-\item{y_title}{Axis title string. Use "" for no title.}
-
-\item{y_transform}{For a numeric y variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
-
-\item{col_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{col_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{col_continuous_type}{For a continuous variable, whether to colour as a "gradient" or in "steps". Defaults to "gradient".}
 
 \item{col_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{col_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{col_expand}{Padding to the limits with \code{ggplot2::expansion()}, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{col_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{col_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{col_legend_ncol}{The number of columns for the legend elements.}
+\item{col_legend_ncol, col_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{col_legend_nrow}{The number of rows for the legend elements.}
-
-\item{col_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{col_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{col_limits}{A vector to determine the limits of the scale.}
 
-\item{col_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{col_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{col_pal}{colours to use. A character vector of hex codes (or names).}
 
-\item{col_pal_na}{colour to use for NA values. A character vector of a hex code (or name).}
+\item{col_pal_na}{colour to use for \code{NA} values. A character vector of a hex code (or name).}
 
-\item{col_rescale}{For a continuous variable, a scales::rescale function.}
+\item{col_rescale}{For a continuous variable, a \code{scales::rescale} function.}
 
 \item{col_title}{Legend title string. Use "" for no title.}
 
-\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
 \item{facet_axes}{Whether to add interior axes and ticks with "margins", "all", "all_x", or "all_y".}
 
 \item{facet_axis_labels}{Whether to add interior axis labels with "margins", "all", "all_x", or "all_y".}
 
-\item{facet_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
+\item{facet_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
 
 \item{facet_labels_position}{When the facet layout is "wrap", the position of the facet labels. Either "top", "right", "bottom" or "left".}
 
 \item{facet_labels_switch}{When the facet layout is "grid", whether to switch the facet labels to the opposite side of the plot. Either "x", "y" or "both".}
 
-\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If NULL and a single facet (or facet2) argument is provided, then defaults to "wrap". If NULL and both facet and facet2 arguments are provided, defaults to "grid".}
+\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If \code{NULL} and a single \code{facet} (or \code{facet2}) argument is provided, then defaults to "wrap". If \code{NULL} and both facet and facet2 arguments are provided, defaults to "grid".}
 
 \item{facet_ncol}{The number of columns of facets. Only applies to a facet layout of "wrap".}
 
@@ -236,31 +216,29 @@ gg_col(
 
 \item{facet_space}{When the facet layout is "grid" and facet scales are not "fixed", whether facet space should be "fixed" across facets, "free" to be proportional in both directions, or free to be proportional in just one direction (i.e. "free_x" or "free_y"). Defaults to "fixed".}
 
-\item{alpha_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{alpha_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{alpha_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{alpha_legend_ncol}{The number of columns for the legend elements.}
+\item{alpha_legend_ncol, alpha_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{alpha_legend_nrow}{The number of rows for the legend elements.}
-
-\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{alpha_limits}{A vector to determine the limits of the scale.}
 
-\item{alpha_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{alpha_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{alpha_pal}{Alpha values to use as a numeric vector. For a continuous variable, a range is only needed.}
 
-\item{alpha_pal_na}{Alpha value to use for the NA value.}
+\item{alpha_pal_na}{Alpha value to use for the \code{NA} value.}
 
-\item{alpha_title}{Legend title string. Use "" for no title.}
+\item{alpha_title}{Legend title string. Use \code{""} for no title.}
 
-\item{alpha_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{alpha_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the transform_ prefix (e.g. "log10").}
 
 \item{title}{Title string.}
 
@@ -268,15 +246,15 @@ gg_col(
 
 \item{caption}{Caption title string.}
 
-\item{titles}{A function to format unspecified titles. Defaults to snakecase::to_sentence_case.}
+\item{titles}{A function to format unspecified titles. Defaults to \code{snakecase::to_sentence_case}.}
 
-\item{flipped}{TRUE or FALSE or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
+\item{flipped}{\code{TRUE} or \code{FALSE} or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
 }
 \value{
 A ggplot object.
 }
 \description{
-Create a col ggplot with a wrapper around ggplot() + geom_col.
+Create a col ggplot with a wrapper around \code{ggplot()} + \link[ggplot2:geom_bar]{geom_col()}.
 }
 \examples{
 

--- a/man/gg_contour.Rd
+++ b/man/gg_contour.Rd
@@ -98,161 +98,139 @@ gg_contour(
 \arguments{
 \item{data}{A data frame or tibble.}
 
-\item{...}{Other arguments passed to within a params list in the layer function.}
+\item{...}{Other arguments passed to within a \code{params} list in \code{layer()}.}
 
 \item{stat}{A statistical transformation to use on the data. A snakecase character string of a ggproto Stat subclass object minus the Stat prefix (e.g. "identity").}
 
-\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a position_* function that outputs a ggproto Position subclass object (e.g. ggplot2::position_identity()).}
+\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a \verb{position_*()} function that outputs a ggproto Position subclass object (e.g. \code{ggplot2::position_identity()}).}
 
-\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. ggplot2::coord_cartesian()).}
+\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. \code{\link[ggplot2:coord_cartesian]{ggplot2::coord_cartesian()}}).}
 
-\item{theme}{A ggplot2 theme (e.g. light_mode_b(), dark_mode_rt() or ggplot2::theme_grey()).}
+\item{theme}{A ggplot2 theme (e.g. \code{\link[=light_mode_b]{light_mode_b()}}, \code{\link[=dark_mode_rt]{dark_mode_rt()}} or \code{\link[ggplot2:ggtheme]{ggplot2::theme_grey()}}).}
 
-\item{x}{Unquoted x aesthetic variable.}
+\item{x}{Unquoted \code{x} aesthetic variable.}
 
-\item{xmin}{Unquoted xmin aesthetic variable.}
+\item{xmin}{Unquoted \code{xmin} aesthetic variable.}
 
-\item{xmax}{Unquoted xmax aesthetic variable.}
+\item{xmax}{Unquoted \code{xmax} aesthetic variable.}
 
-\item{xend}{Unquoted xend aesthetic variable.}
+\item{xend}{Unquoted \code{xend} aesthetic variable.}
 
-\item{y}{Unquoted y aesthetic variable.}
+\item{y}{Unquoted \code{y} aesthetic variable.}
 
-\item{ymin}{Unquoted ymin aesthetic variable.}
+\item{ymin}{Unquoted \code{ymin} aesthetic variable.}
 
-\item{ymax}{Unquoted ymax aesthetic variable.}
+\item{ymax}{Unquoted \code{ymax} aesthetic variable.}
 
-\item{yend}{Unquoted yend aesthetic variable.}
+\item{yend}{Unquoted \code{yend} aesthetic variable.}
 
-\item{z}{Unquoted z aesthetic variable.}
+\item{z}{Unquoted \code{z} aesthetic variable.}
 
-\item{col}{Unquoted col and fill aesthetic variable.}
+\item{col}{Unquoted \code{col} and \code{fill} aesthetic variable.}
 
-\item{alpha}{Unquoted alpha aesthetic variable.}
+\item{alpha}{Unquoted \code{alpha} aesthetic variable.}
 
-\item{facet}{Unquoted facet aesthetic variable.}
+\item{facet}{Unquoted \code{facet} aesthetic variable.}
 
 \item{facet2}{Unquoted second facet variable.}
 
-\item{group}{Unquoted group aesthetic variable.}
+\item{group}{Unquoted \code{group} aesthetic variable.}
 
-\item{subgroup}{Unquoted subgroup aesthetic variable.}
+\item{subgroup}{Unquoted \code{subgroup} aesthetic variable.}
 
-\item{label}{Unquoted label aesthetic variable.}
+\item{label}{Unquoted \code{label} aesthetic variable.}
 
-\item{text}{Unquoted text aesthetic variable.}
+\item{text}{Unquoted \code{text} aesthetic variable.}
 
-\item{sample}{Unquoted sample aesthetic variable.}
+\item{sample}{Unquoted \code{sample} aesthetic variable.}
 
-\item{mapping}{Set of additional aesthetic mappings within the ggplot2::aes function for non-supported aesthetics (e.g. shape, linetype, linewidth, or size) or for delayed evaluation.}
+\item{mapping}{Set of additional aesthetic mappings within \code{ggplot2::aes()} for non-supported aesthetics (e.g. \code{shape}, \code{linetype}, \code{linewidth}, or \code{size}) or for delayed evaluation.}
 
-\item{x_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{x_breaks, y_breaks}{A \verb{scales::breaks_*} function (e.g. \code{\link[scales:breaks_pretty]{scales::breaks_pretty()}}), or a vector of breaks.}
 
-\item{x_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{x_expand, y_expand}{Padding to the limits with the \code{ggplot2::expansion()} function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{x_expand_limits}{For a continuous x variable, any values that the limits should encompass (e.g. 0).}
+\item{x_expand_limits, y_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{x_gridlines}{TRUE or FALSE for vertical x gridlines. NULL guesses based on the classes of the x and y.}
+\item{x_gridlines}{\code{TRUE} or \code{FALSE} for vertical \code{x} gridlines. \code{NULL} guesses based on the classes of the x and y.}
 
-\item{x_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{x_labels, y_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{\link[scales:label_number]{scales::label_comma()}}), or a vector of labels.}
 
-\item{x_limits}{A vector of length 2 to determine the limits of the axis.}
+\item{x_limits, y_limits}{A vector of length 2 to determine the limits of the axis.}
 
-\item{x_oob}{For a continuous x variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{x_oob, y_oob}{For a continuous \code{x} variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
-\item{x_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
+\item{x_sec_axis, y_sec_axis}{A secondary axis using \code{ggplot2::sec_axis()} or \code{ggplot2::dup_axis()}.}
 
-\item{x_title}{Axis title string. Use "" for no title.}
+\item{x_title, y_title}{Axis title string. Use \code{""} for no title.}
 
-\item{x_transform}{For a numeric x variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{x_transform, y_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{y_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{y_gridlines}{\code{TRUE} or \code{FALSE} of horizontal \code{y} gridlines. \code{NULL} guesses based on the classes of the \code{x} and \code{y}.}
 
-\item{y_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
-
-\item{y_expand_limits}{For a continuous y variable, any values that the limits should encompass (e.g. 0).}
-
-\item{y_gridlines}{TRUE or FALSE of horizontal y gridlines. NULL guesses based on the classes of the x and y.}
-
-\item{y_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
-
-\item{y_limits}{A vector of length 2 to determine the limits of the axis.}
-
-\item{y_oob}{For a continuous y variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
-
-\item{y_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
-
-\item{y_title}{Axis title string. Use "" for no title.}
-
-\item{y_transform}{For a numeric y variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
-
-\item{col_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{col_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{col_continuous_type}{For a continuous variable, whether to colour as a "gradient" or in "steps". Defaults to "gradient".}
 
 \item{col_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{col_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{col_expand}{Padding to the limits with \code{ggplot2::expansion()}, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{col_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{col_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{col_legend_ncol}{The number of columns for the legend elements.}
+\item{col_legend_ncol, col_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{col_legend_nrow}{The number of rows for the legend elements.}
-
-\item{col_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{col_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{col_limits}{A vector to determine the limits of the scale.}
 
-\item{col_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{col_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{col_pal}{colours to use. A character vector of hex codes (or names).}
 
-\item{col_pal_na}{colour to use for NA values. A character vector of a hex code (or name).}
+\item{col_pal_na}{colour to use for \code{NA} values. A character vector of a hex code (or name).}
 
-\item{col_rescale}{For a continuous variable, a scales::rescale function.}
+\item{col_rescale}{For a continuous variable, a \code{scales::rescale} function.}
 
 \item{col_title}{Legend title string. Use "" for no title.}
 
-\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{alpha_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{alpha_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{alpha_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{alpha_legend_ncol}{The number of columns for the legend elements.}
+\item{alpha_legend_ncol, alpha_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{alpha_legend_nrow}{The number of rows for the legend elements.}
-
-\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{alpha_limits}{A vector to determine the limits of the scale.}
 
-\item{alpha_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{alpha_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{alpha_pal}{Alpha values to use as a numeric vector. For a continuous variable, a range is only needed.}
 
-\item{alpha_pal_na}{Alpha value to use for the NA value.}
+\item{alpha_pal_na}{Alpha value to use for the \code{NA} value.}
 
-\item{alpha_title}{Legend title string. Use "" for no title.}
+\item{alpha_title}{Legend title string. Use \code{""} for no title.}
 
-\item{alpha_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{alpha_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the transform_ prefix (e.g. "log10").}
 
 \item{facet_axes}{Whether to add interior axes and ticks with "margins", "all", "all_x", or "all_y".}
 
 \item{facet_axis_labels}{Whether to add interior axis labels with "margins", "all", "all_x", or "all_y".}
 
-\item{facet_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
+\item{facet_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
 
 \item{facet_labels_position}{When the facet layout is "wrap", the position of the facet labels. Either "top", "right", "bottom" or "left".}
 
 \item{facet_labels_switch}{When the facet layout is "grid", whether to switch the facet labels to the opposite side of the plot. Either "x", "y" or "both".}
 
-\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If NULL and a single facet (or facet2) argument is provided, then defaults to "wrap". If NULL and both facet and facet2 arguments are provided, defaults to "grid".}
+\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If \code{NULL} and a single \code{facet} (or \code{facet2}) argument is provided, then defaults to "wrap". If \code{NULL} and both facet and facet2 arguments are provided, defaults to "grid".}
 
 \item{facet_ncol}{The number of columns of facets. Only applies to a facet layout of "wrap".}
 
@@ -268,15 +246,15 @@ gg_contour(
 
 \item{caption}{Caption title string.}
 
-\item{titles}{A function to format unspecified titles. Defaults to snakecase::to_sentence_case.}
+\item{titles}{A function to format unspecified titles. Defaults to \code{snakecase::to_sentence_case}.}
 
-\item{flipped}{TRUE or FALSE or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
+\item{flipped}{\code{TRUE} or \code{FALSE} or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
 }
 \value{
 A ggplot object.
 }
 \description{
-Create a contour ggplot with a wrapper around ggplot() + geom_contour.
+Create a contour ggplot with a wrapper around \code{ggplot()} + \link[ggplot2:geom_contour]{geom_contour()}.
 }
 \examples{
 

--- a/man/gg_contour_filled.Rd
+++ b/man/gg_contour_filled.Rd
@@ -98,161 +98,139 @@ gg_contour_filled(
 \arguments{
 \item{data}{A data frame or tibble.}
 
-\item{...}{Other arguments passed to within a params list in the layer function.}
+\item{...}{Other arguments passed to within a \code{params} list in \code{layer()}.}
 
 \item{stat}{A statistical transformation to use on the data. A snakecase character string of a ggproto Stat subclass object minus the Stat prefix (e.g. "identity").}
 
-\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a position_* function that outputs a ggproto Position subclass object (e.g. ggplot2::position_identity()).}
+\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a \verb{position_*()} function that outputs a ggproto Position subclass object (e.g. \code{ggplot2::position_identity()}).}
 
-\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. ggplot2::coord_cartesian()).}
+\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. \code{\link[ggplot2:coord_cartesian]{ggplot2::coord_cartesian()}}).}
 
-\item{theme}{A ggplot2 theme (e.g. light_mode_b(), dark_mode_rt() or ggplot2::theme_grey()).}
+\item{theme}{A ggplot2 theme (e.g. \code{\link[=light_mode_b]{light_mode_b()}}, \code{\link[=dark_mode_rt]{dark_mode_rt()}} or \code{\link[ggplot2:ggtheme]{ggplot2::theme_grey()}}).}
 
-\item{x}{Unquoted x aesthetic variable.}
+\item{x}{Unquoted \code{x} aesthetic variable.}
 
-\item{xmin}{Unquoted xmin aesthetic variable.}
+\item{xmin}{Unquoted \code{xmin} aesthetic variable.}
 
-\item{xmax}{Unquoted xmax aesthetic variable.}
+\item{xmax}{Unquoted \code{xmax} aesthetic variable.}
 
-\item{xend}{Unquoted xend aesthetic variable.}
+\item{xend}{Unquoted \code{xend} aesthetic variable.}
 
-\item{y}{Unquoted y aesthetic variable.}
+\item{y}{Unquoted \code{y} aesthetic variable.}
 
-\item{ymin}{Unquoted ymin aesthetic variable.}
+\item{ymin}{Unquoted \code{ymin} aesthetic variable.}
 
-\item{ymax}{Unquoted ymax aesthetic variable.}
+\item{ymax}{Unquoted \code{ymax} aesthetic variable.}
 
-\item{yend}{Unquoted yend aesthetic variable.}
+\item{yend}{Unquoted \code{yend} aesthetic variable.}
 
-\item{z}{Unquoted z aesthetic variable.}
+\item{z}{Unquoted \code{z} aesthetic variable.}
 
-\item{col}{Unquoted col and fill aesthetic variable.}
+\item{col}{Unquoted \code{col} and \code{fill} aesthetic variable.}
 
-\item{alpha}{Unquoted alpha aesthetic variable.}
+\item{alpha}{Unquoted \code{alpha} aesthetic variable.}
 
-\item{facet}{Unquoted facet aesthetic variable.}
+\item{facet}{Unquoted \code{facet} aesthetic variable.}
 
 \item{facet2}{Unquoted second facet variable.}
 
-\item{group}{Unquoted group aesthetic variable.}
+\item{group}{Unquoted \code{group} aesthetic variable.}
 
-\item{subgroup}{Unquoted subgroup aesthetic variable.}
+\item{subgroup}{Unquoted \code{subgroup} aesthetic variable.}
 
-\item{label}{Unquoted label aesthetic variable.}
+\item{label}{Unquoted \code{label} aesthetic variable.}
 
-\item{text}{Unquoted text aesthetic variable.}
+\item{text}{Unquoted \code{text} aesthetic variable.}
 
-\item{sample}{Unquoted sample aesthetic variable.}
+\item{sample}{Unquoted \code{sample} aesthetic variable.}
 
-\item{mapping}{Set of additional aesthetic mappings within the ggplot2::aes function for non-supported aesthetics (e.g. shape, linetype, linewidth, or size) or for delayed evaluation.}
+\item{mapping}{Set of additional aesthetic mappings within \code{ggplot2::aes()} for non-supported aesthetics (e.g. \code{shape}, \code{linetype}, \code{linewidth}, or \code{size}) or for delayed evaluation.}
 
-\item{x_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{x_breaks, y_breaks}{A \verb{scales::breaks_*} function (e.g. \code{\link[scales:breaks_pretty]{scales::breaks_pretty()}}), or a vector of breaks.}
 
-\item{x_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{x_expand, y_expand}{Padding to the limits with the \code{ggplot2::expansion()} function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{x_expand_limits}{For a continuous x variable, any values that the limits should encompass (e.g. 0).}
+\item{x_expand_limits, y_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{x_gridlines}{TRUE or FALSE for vertical x gridlines. NULL guesses based on the classes of the x and y.}
+\item{x_gridlines}{\code{TRUE} or \code{FALSE} for vertical \code{x} gridlines. \code{NULL} guesses based on the classes of the x and y.}
 
-\item{x_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{x_labels, y_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{\link[scales:label_number]{scales::label_comma()}}), or a vector of labels.}
 
-\item{x_limits}{A vector of length 2 to determine the limits of the axis.}
+\item{x_limits, y_limits}{A vector of length 2 to determine the limits of the axis.}
 
-\item{x_oob}{For a continuous x variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{x_oob, y_oob}{For a continuous \code{x} variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
-\item{x_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
+\item{x_sec_axis, y_sec_axis}{A secondary axis using \code{ggplot2::sec_axis()} or \code{ggplot2::dup_axis()}.}
 
-\item{x_title}{Axis title string. Use "" for no title.}
+\item{x_title, y_title}{Axis title string. Use \code{""} for no title.}
 
-\item{x_transform}{For a numeric x variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{x_transform, y_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{y_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{y_gridlines}{\code{TRUE} or \code{FALSE} of horizontal \code{y} gridlines. \code{NULL} guesses based on the classes of the \code{x} and \code{y}.}
 
-\item{y_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
-
-\item{y_expand_limits}{For a continuous y variable, any values that the limits should encompass (e.g. 0).}
-
-\item{y_gridlines}{TRUE or FALSE of horizontal y gridlines. NULL guesses based on the classes of the x and y.}
-
-\item{y_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
-
-\item{y_limits}{A vector of length 2 to determine the limits of the axis.}
-
-\item{y_oob}{For a continuous y variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
-
-\item{y_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
-
-\item{y_title}{Axis title string. Use "" for no title.}
-
-\item{y_transform}{For a numeric y variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
-
-\item{col_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{col_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{col_continuous_type}{For a continuous variable, whether to colour as a "gradient" or in "steps". Defaults to "gradient".}
 
 \item{col_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{col_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{col_expand}{Padding to the limits with \code{ggplot2::expansion()}, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{col_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{col_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{col_legend_ncol}{The number of columns for the legend elements.}
+\item{col_legend_ncol, col_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{col_legend_nrow}{The number of rows for the legend elements.}
-
-\item{col_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{col_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{col_limits}{A vector to determine the limits of the scale.}
 
-\item{col_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{col_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{col_pal}{colours to use. A character vector of hex codes (or names).}
 
-\item{col_pal_na}{colour to use for NA values. A character vector of a hex code (or name).}
+\item{col_pal_na}{colour to use for \code{NA} values. A character vector of a hex code (or name).}
 
-\item{col_rescale}{For a continuous variable, a scales::rescale function.}
+\item{col_rescale}{For a continuous variable, a \code{scales::rescale} function.}
 
 \item{col_title}{Legend title string. Use "" for no title.}
 
-\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{alpha_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{alpha_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{alpha_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{alpha_legend_ncol}{The number of columns for the legend elements.}
+\item{alpha_legend_ncol, alpha_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{alpha_legend_nrow}{The number of rows for the legend elements.}
-
-\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{alpha_limits}{A vector to determine the limits of the scale.}
 
-\item{alpha_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{alpha_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{alpha_pal}{Alpha values to use as a numeric vector. For a continuous variable, a range is only needed.}
 
-\item{alpha_pal_na}{Alpha value to use for the NA value.}
+\item{alpha_pal_na}{Alpha value to use for the \code{NA} value.}
 
-\item{alpha_title}{Legend title string. Use "" for no title.}
+\item{alpha_title}{Legend title string. Use \code{""} for no title.}
 
-\item{alpha_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{alpha_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the transform_ prefix (e.g. "log10").}
 
 \item{facet_axes}{Whether to add interior axes and ticks with "margins", "all", "all_x", or "all_y".}
 
 \item{facet_axis_labels}{Whether to add interior axis labels with "margins", "all", "all_x", or "all_y".}
 
-\item{facet_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
+\item{facet_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
 
 \item{facet_labels_position}{When the facet layout is "wrap", the position of the facet labels. Either "top", "right", "bottom" or "left".}
 
 \item{facet_labels_switch}{When the facet layout is "grid", whether to switch the facet labels to the opposite side of the plot. Either "x", "y" or "both".}
 
-\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If NULL and a single facet (or facet2) argument is provided, then defaults to "wrap". If NULL and both facet and facet2 arguments are provided, defaults to "grid".}
+\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If \code{NULL} and a single \code{facet} (or \code{facet2}) argument is provided, then defaults to "wrap". If \code{NULL} and both facet and facet2 arguments are provided, defaults to "grid".}
 
 \item{facet_ncol}{The number of columns of facets. Only applies to a facet layout of "wrap".}
 
@@ -268,15 +246,15 @@ gg_contour_filled(
 
 \item{caption}{Caption title string.}
 
-\item{titles}{A function to format unspecified titles. Defaults to snakecase::to_sentence_case.}
+\item{titles}{A function to format unspecified titles. Defaults to \code{snakecase::to_sentence_case}.}
 
-\item{flipped}{TRUE or FALSE or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
+\item{flipped}{\code{TRUE} or \code{FALSE} or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
 }
 \value{
 A ggplot object.
 }
 \description{
-Create a contour_filled ggplot with a wrapper around ggplot() + geom_contour_filled.
+Create a contour_filled ggplot with a wrapper around \code{ggplot()} + \link[ggplot2:geom_contour]{geom_contour_filled()}.
 }
 \examples{
 

--- a/man/gg_crossbar.Rd
+++ b/man/gg_crossbar.Rd
@@ -98,161 +98,139 @@ gg_crossbar(
 \arguments{
 \item{data}{A data frame or tibble.}
 
-\item{...}{Other arguments passed to within a params list in the layer function.}
+\item{...}{Other arguments passed to within a \code{params} list in \code{layer()}.}
 
 \item{stat}{A statistical transformation to use on the data. A snakecase character string of a ggproto Stat subclass object minus the Stat prefix (e.g. "identity").}
 
-\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a position_* function that outputs a ggproto Position subclass object (e.g. ggplot2::position_identity()).}
+\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a \verb{position_*()} function that outputs a ggproto Position subclass object (e.g. \code{ggplot2::position_identity()}).}
 
-\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. ggplot2::coord_cartesian()).}
+\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. \code{\link[ggplot2:coord_cartesian]{ggplot2::coord_cartesian()}}).}
 
-\item{theme}{A ggplot2 theme (e.g. light_mode_b(), dark_mode_rt() or ggplot2::theme_grey()).}
+\item{theme}{A ggplot2 theme (e.g. \code{\link[=light_mode_b]{light_mode_b()}}, \code{\link[=dark_mode_rt]{dark_mode_rt()}} or \code{\link[ggplot2:ggtheme]{ggplot2::theme_grey()}}).}
 
-\item{x}{Unquoted x aesthetic variable.}
+\item{x}{Unquoted \code{x} aesthetic variable.}
 
-\item{xmin}{Unquoted xmin aesthetic variable.}
+\item{xmin}{Unquoted \code{xmin} aesthetic variable.}
 
-\item{xmax}{Unquoted xmax aesthetic variable.}
+\item{xmax}{Unquoted \code{xmax} aesthetic variable.}
 
-\item{xend}{Unquoted xend aesthetic variable.}
+\item{xend}{Unquoted \code{xend} aesthetic variable.}
 
-\item{y}{Unquoted y aesthetic variable.}
+\item{y}{Unquoted \code{y} aesthetic variable.}
 
-\item{ymin}{Unquoted ymin aesthetic variable.}
+\item{ymin}{Unquoted \code{ymin} aesthetic variable.}
 
-\item{ymax}{Unquoted ymax aesthetic variable.}
+\item{ymax}{Unquoted \code{ymax} aesthetic variable.}
 
-\item{yend}{Unquoted yend aesthetic variable.}
+\item{yend}{Unquoted \code{yend} aesthetic variable.}
 
-\item{z}{Unquoted z aesthetic variable.}
+\item{z}{Unquoted \code{z} aesthetic variable.}
 
-\item{col}{Unquoted col and fill aesthetic variable.}
+\item{col}{Unquoted \code{col} and \code{fill} aesthetic variable.}
 
-\item{alpha}{Unquoted alpha aesthetic variable.}
+\item{alpha}{Unquoted \code{alpha} aesthetic variable.}
 
-\item{facet}{Unquoted facet aesthetic variable.}
+\item{facet}{Unquoted \code{facet} aesthetic variable.}
 
 \item{facet2}{Unquoted second facet variable.}
 
-\item{group}{Unquoted group aesthetic variable.}
+\item{group}{Unquoted \code{group} aesthetic variable.}
 
-\item{subgroup}{Unquoted subgroup aesthetic variable.}
+\item{subgroup}{Unquoted \code{subgroup} aesthetic variable.}
 
-\item{label}{Unquoted label aesthetic variable.}
+\item{label}{Unquoted \code{label} aesthetic variable.}
 
-\item{text}{Unquoted text aesthetic variable.}
+\item{text}{Unquoted \code{text} aesthetic variable.}
 
-\item{sample}{Unquoted sample aesthetic variable.}
+\item{sample}{Unquoted \code{sample} aesthetic variable.}
 
-\item{mapping}{Set of additional aesthetic mappings within the ggplot2::aes function for non-supported aesthetics (e.g. shape, linetype, linewidth, or size) or for delayed evaluation.}
+\item{mapping}{Set of additional aesthetic mappings within \code{ggplot2::aes()} for non-supported aesthetics (e.g. \code{shape}, \code{linetype}, \code{linewidth}, or \code{size}) or for delayed evaluation.}
 
-\item{x_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{x_breaks, y_breaks}{A \verb{scales::breaks_*} function (e.g. \code{\link[scales:breaks_pretty]{scales::breaks_pretty()}}), or a vector of breaks.}
 
-\item{x_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{x_expand, y_expand}{Padding to the limits with the \code{ggplot2::expansion()} function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{x_expand_limits}{For a continuous x variable, any values that the limits should encompass (e.g. 0).}
+\item{x_expand_limits, y_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{x_gridlines}{TRUE or FALSE for vertical x gridlines. NULL guesses based on the classes of the x and y.}
+\item{x_gridlines}{\code{TRUE} or \code{FALSE} for vertical \code{x} gridlines. \code{NULL} guesses based on the classes of the x and y.}
 
-\item{x_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{x_labels, y_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{\link[scales:label_number]{scales::label_comma()}}), or a vector of labels.}
 
-\item{x_limits}{A vector of length 2 to determine the limits of the axis.}
+\item{x_limits, y_limits}{A vector of length 2 to determine the limits of the axis.}
 
-\item{x_oob}{For a continuous x variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{x_oob, y_oob}{For a continuous \code{x} variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
-\item{x_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
+\item{x_sec_axis, y_sec_axis}{A secondary axis using \code{ggplot2::sec_axis()} or \code{ggplot2::dup_axis()}.}
 
-\item{x_title}{Axis title string. Use "" for no title.}
+\item{x_title, y_title}{Axis title string. Use \code{""} for no title.}
 
-\item{x_transform}{For a numeric x variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{x_transform, y_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{y_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{y_gridlines}{\code{TRUE} or \code{FALSE} of horizontal \code{y} gridlines. \code{NULL} guesses based on the classes of the \code{x} and \code{y}.}
 
-\item{y_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
-
-\item{y_expand_limits}{For a continuous y variable, any values that the limits should encompass (e.g. 0).}
-
-\item{y_gridlines}{TRUE or FALSE of horizontal y gridlines. NULL guesses based on the classes of the x and y.}
-
-\item{y_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
-
-\item{y_limits}{A vector of length 2 to determine the limits of the axis.}
-
-\item{y_oob}{For a continuous y variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
-
-\item{y_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
-
-\item{y_title}{Axis title string. Use "" for no title.}
-
-\item{y_transform}{For a numeric y variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
-
-\item{col_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{col_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{col_continuous_type}{For a continuous variable, whether to colour as a "gradient" or in "steps". Defaults to "gradient".}
 
 \item{col_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{col_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{col_expand}{Padding to the limits with \code{ggplot2::expansion()}, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{col_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{col_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{col_legend_ncol}{The number of columns for the legend elements.}
+\item{col_legend_ncol, col_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{col_legend_nrow}{The number of rows for the legend elements.}
-
-\item{col_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{col_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{col_limits}{A vector to determine the limits of the scale.}
 
-\item{col_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{col_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{col_pal}{colours to use. A character vector of hex codes (or names).}
 
-\item{col_pal_na}{colour to use for NA values. A character vector of a hex code (or name).}
+\item{col_pal_na}{colour to use for \code{NA} values. A character vector of a hex code (or name).}
 
-\item{col_rescale}{For a continuous variable, a scales::rescale function.}
+\item{col_rescale}{For a continuous variable, a \code{scales::rescale} function.}
 
 \item{col_title}{Legend title string. Use "" for no title.}
 
-\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{alpha_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{alpha_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{alpha_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{alpha_legend_ncol}{The number of columns for the legend elements.}
+\item{alpha_legend_ncol, alpha_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{alpha_legend_nrow}{The number of rows for the legend elements.}
-
-\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{alpha_limits}{A vector to determine the limits of the scale.}
 
-\item{alpha_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{alpha_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{alpha_pal}{Alpha values to use as a numeric vector. For a continuous variable, a range is only needed.}
 
-\item{alpha_pal_na}{Alpha value to use for the NA value.}
+\item{alpha_pal_na}{Alpha value to use for the \code{NA} value.}
 
-\item{alpha_title}{Legend title string. Use "" for no title.}
+\item{alpha_title}{Legend title string. Use \code{""} for no title.}
 
-\item{alpha_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{alpha_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the transform_ prefix (e.g. "log10").}
 
 \item{facet_axes}{Whether to add interior axes and ticks with "margins", "all", "all_x", or "all_y".}
 
 \item{facet_axis_labels}{Whether to add interior axis labels with "margins", "all", "all_x", or "all_y".}
 
-\item{facet_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
+\item{facet_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
 
 \item{facet_labels_position}{When the facet layout is "wrap", the position of the facet labels. Either "top", "right", "bottom" or "left".}
 
 \item{facet_labels_switch}{When the facet layout is "grid", whether to switch the facet labels to the opposite side of the plot. Either "x", "y" or "both".}
 
-\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If NULL and a single facet (or facet2) argument is provided, then defaults to "wrap". If NULL and both facet and facet2 arguments are provided, defaults to "grid".}
+\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If \code{NULL} and a single \code{facet} (or \code{facet2}) argument is provided, then defaults to "wrap". If \code{NULL} and both facet and facet2 arguments are provided, defaults to "grid".}
 
 \item{facet_ncol}{The number of columns of facets. Only applies to a facet layout of "wrap".}
 
@@ -268,15 +246,15 @@ gg_crossbar(
 
 \item{caption}{Caption title string.}
 
-\item{titles}{A function to format unspecified titles. Defaults to snakecase::to_sentence_case.}
+\item{titles}{A function to format unspecified titles. Defaults to \code{snakecase::to_sentence_case}.}
 
-\item{flipped}{TRUE or FALSE or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
+\item{flipped}{\code{TRUE} or \code{FALSE} or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
 }
 \value{
 A ggplot object.
 }
 \description{
-Create a crossbar ggplot with a wrapper around ggplot() + geom_crossbar.
+Create a crossbar ggplot with a wrapper around \code{ggplot()} + \link[ggplot2:geom_linerange]{geom_crossbar()}.
 }
 \examples{
 

--- a/man/gg_density.Rd
+++ b/man/gg_density.Rd
@@ -98,161 +98,139 @@ gg_density(
 \arguments{
 \item{data}{A data frame or tibble.}
 
-\item{...}{Other arguments passed to within a params list in the layer function.}
+\item{...}{Other arguments passed to within a \code{params} list in \code{layer()}.}
 
 \item{stat}{A statistical transformation to use on the data. A snakecase character string of a ggproto Stat subclass object minus the Stat prefix (e.g. "identity").}
 
-\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a position_* function that outputs a ggproto Position subclass object (e.g. ggplot2::position_identity()).}
+\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a \verb{position_*()} function that outputs a ggproto Position subclass object (e.g. \code{ggplot2::position_identity()}).}
 
-\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. ggplot2::coord_cartesian()).}
+\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. \code{\link[ggplot2:coord_cartesian]{ggplot2::coord_cartesian()}}).}
 
-\item{theme}{A ggplot2 theme (e.g. light_mode_b(), dark_mode_rt() or ggplot2::theme_grey()).}
+\item{theme}{A ggplot2 theme (e.g. \code{\link[=light_mode_b]{light_mode_b()}}, \code{\link[=dark_mode_rt]{dark_mode_rt()}} or \code{\link[ggplot2:ggtheme]{ggplot2::theme_grey()}}).}
 
-\item{x}{Unquoted x aesthetic variable.}
+\item{x}{Unquoted \code{x} aesthetic variable.}
 
-\item{xmin}{Unquoted xmin aesthetic variable.}
+\item{xmin}{Unquoted \code{xmin} aesthetic variable.}
 
-\item{xmax}{Unquoted xmax aesthetic variable.}
+\item{xmax}{Unquoted \code{xmax} aesthetic variable.}
 
-\item{xend}{Unquoted xend aesthetic variable.}
+\item{xend}{Unquoted \code{xend} aesthetic variable.}
 
-\item{y}{Unquoted y aesthetic variable.}
+\item{y}{Unquoted \code{y} aesthetic variable.}
 
-\item{ymin}{Unquoted ymin aesthetic variable.}
+\item{ymin}{Unquoted \code{ymin} aesthetic variable.}
 
-\item{ymax}{Unquoted ymax aesthetic variable.}
+\item{ymax}{Unquoted \code{ymax} aesthetic variable.}
 
-\item{yend}{Unquoted yend aesthetic variable.}
+\item{yend}{Unquoted \code{yend} aesthetic variable.}
 
-\item{z}{Unquoted z aesthetic variable.}
+\item{z}{Unquoted \code{z} aesthetic variable.}
 
-\item{col}{Unquoted col and fill aesthetic variable.}
+\item{col}{Unquoted \code{col} and \code{fill} aesthetic variable.}
 
-\item{alpha}{Unquoted alpha aesthetic variable.}
+\item{alpha}{Unquoted \code{alpha} aesthetic variable.}
 
-\item{facet}{Unquoted facet aesthetic variable.}
+\item{facet}{Unquoted \code{facet} aesthetic variable.}
 
 \item{facet2}{Unquoted second facet variable.}
 
-\item{group}{Unquoted group aesthetic variable.}
+\item{group}{Unquoted \code{group} aesthetic variable.}
 
-\item{subgroup}{Unquoted subgroup aesthetic variable.}
+\item{subgroup}{Unquoted \code{subgroup} aesthetic variable.}
 
-\item{label}{Unquoted label aesthetic variable.}
+\item{label}{Unquoted \code{label} aesthetic variable.}
 
-\item{text}{Unquoted text aesthetic variable.}
+\item{text}{Unquoted \code{text} aesthetic variable.}
 
-\item{sample}{Unquoted sample aesthetic variable.}
+\item{sample}{Unquoted \code{sample} aesthetic variable.}
 
-\item{mapping}{Set of additional aesthetic mappings within the ggplot2::aes function for non-supported aesthetics (e.g. shape, linetype, linewidth, or size) or for delayed evaluation.}
+\item{mapping}{Set of additional aesthetic mappings within \code{ggplot2::aes()} for non-supported aesthetics (e.g. \code{shape}, \code{linetype}, \code{linewidth}, or \code{size}) or for delayed evaluation.}
 
-\item{x_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{x_breaks, y_breaks}{A \verb{scales::breaks_*} function (e.g. \code{\link[scales:breaks_pretty]{scales::breaks_pretty()}}), or a vector of breaks.}
 
-\item{x_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{x_expand, y_expand}{Padding to the limits with the \code{ggplot2::expansion()} function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{x_expand_limits}{For a continuous x variable, any values that the limits should encompass (e.g. 0).}
+\item{x_expand_limits, y_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{x_gridlines}{TRUE or FALSE for vertical x gridlines. NULL guesses based on the classes of the x and y.}
+\item{x_gridlines}{\code{TRUE} or \code{FALSE} for vertical \code{x} gridlines. \code{NULL} guesses based on the classes of the x and y.}
 
-\item{x_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{x_labels, y_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{\link[scales:label_number]{scales::label_comma()}}), or a vector of labels.}
 
-\item{x_limits}{A vector of length 2 to determine the limits of the axis.}
+\item{x_limits, y_limits}{A vector of length 2 to determine the limits of the axis.}
 
-\item{x_oob}{For a continuous x variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{x_oob, y_oob}{For a continuous \code{x} variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
-\item{x_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
+\item{x_sec_axis, y_sec_axis}{A secondary axis using \code{ggplot2::sec_axis()} or \code{ggplot2::dup_axis()}.}
 
-\item{x_title}{Axis title string. Use "" for no title.}
+\item{x_title, y_title}{Axis title string. Use \code{""} for no title.}
 
-\item{x_transform}{For a numeric x variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{x_transform, y_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{y_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{y_gridlines}{\code{TRUE} or \code{FALSE} of horizontal \code{y} gridlines. \code{NULL} guesses based on the classes of the \code{x} and \code{y}.}
 
-\item{y_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
-
-\item{y_expand_limits}{For a continuous y variable, any values that the limits should encompass (e.g. 0).}
-
-\item{y_gridlines}{TRUE or FALSE of horizontal y gridlines. NULL guesses based on the classes of the x and y.}
-
-\item{y_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
-
-\item{y_limits}{A vector of length 2 to determine the limits of the axis.}
-
-\item{y_oob}{For a continuous y variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
-
-\item{y_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
-
-\item{y_title}{Axis title string. Use "" for no title.}
-
-\item{y_transform}{For a numeric y variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
-
-\item{col_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{col_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{col_continuous_type}{For a continuous variable, whether to colour as a "gradient" or in "steps". Defaults to "gradient".}
 
 \item{col_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{col_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{col_expand}{Padding to the limits with \code{ggplot2::expansion()}, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{col_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{col_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{col_legend_ncol}{The number of columns for the legend elements.}
+\item{col_legend_ncol, col_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{col_legend_nrow}{The number of rows for the legend elements.}
-
-\item{col_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{col_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{col_limits}{A vector to determine the limits of the scale.}
 
-\item{col_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{col_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{col_pal}{colours to use. A character vector of hex codes (or names).}
 
-\item{col_pal_na}{colour to use for NA values. A character vector of a hex code (or name).}
+\item{col_pal_na}{colour to use for \code{NA} values. A character vector of a hex code (or name).}
 
-\item{col_rescale}{For a continuous variable, a scales::rescale function.}
+\item{col_rescale}{For a continuous variable, a \code{scales::rescale} function.}
 
 \item{col_title}{Legend title string. Use "" for no title.}
 
-\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{alpha_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{alpha_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{alpha_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{alpha_legend_ncol}{The number of columns for the legend elements.}
+\item{alpha_legend_ncol, alpha_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{alpha_legend_nrow}{The number of rows for the legend elements.}
-
-\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{alpha_limits}{A vector to determine the limits of the scale.}
 
-\item{alpha_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{alpha_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{alpha_pal}{Alpha values to use as a numeric vector. For a continuous variable, a range is only needed.}
 
-\item{alpha_pal_na}{Alpha value to use for the NA value.}
+\item{alpha_pal_na}{Alpha value to use for the \code{NA} value.}
 
-\item{alpha_title}{Legend title string. Use "" for no title.}
+\item{alpha_title}{Legend title string. Use \code{""} for no title.}
 
-\item{alpha_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{alpha_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the transform_ prefix (e.g. "log10").}
 
 \item{facet_axes}{Whether to add interior axes and ticks with "margins", "all", "all_x", or "all_y".}
 
 \item{facet_axis_labels}{Whether to add interior axis labels with "margins", "all", "all_x", or "all_y".}
 
-\item{facet_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
+\item{facet_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
 
 \item{facet_labels_position}{When the facet layout is "wrap", the position of the facet labels. Either "top", "right", "bottom" or "left".}
 
 \item{facet_labels_switch}{When the facet layout is "grid", whether to switch the facet labels to the opposite side of the plot. Either "x", "y" or "both".}
 
-\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If NULL and a single facet (or facet2) argument is provided, then defaults to "wrap". If NULL and both facet and facet2 arguments are provided, defaults to "grid".}
+\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If \code{NULL} and a single \code{facet} (or \code{facet2}) argument is provided, then defaults to "wrap". If \code{NULL} and both facet and facet2 arguments are provided, defaults to "grid".}
 
 \item{facet_ncol}{The number of columns of facets. Only applies to a facet layout of "wrap".}
 
@@ -268,15 +246,15 @@ gg_density(
 
 \item{caption}{Caption title string.}
 
-\item{titles}{A function to format unspecified titles. Defaults to snakecase::to_sentence_case.}
+\item{titles}{A function to format unspecified titles. Defaults to \code{snakecase::to_sentence_case}.}
 
-\item{flipped}{TRUE or FALSE or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
+\item{flipped}{\code{TRUE} or \code{FALSE} or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
 }
 \value{
 A ggplot object.
 }
 \description{
-Create a density ggplot with a wrapper around ggplot() + geom_density.
+Create a density ggplot with a wrapper around \code{ggplot()} + \link[ggplot2:geom_density]{geom_density()}.
 }
 \examples{
 

--- a/man/gg_density_2d.Rd
+++ b/man/gg_density_2d.Rd
@@ -98,161 +98,139 @@ gg_density_2d(
 \arguments{
 \item{data}{A data frame or tibble.}
 
-\item{...}{Other arguments passed to within a params list in the layer function.}
+\item{...}{Other arguments passed to within a \code{params} list in \code{layer()}.}
 
 \item{stat}{A statistical transformation to use on the data. A snakecase character string of a ggproto Stat subclass object minus the Stat prefix (e.g. "identity").}
 
-\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a position_* function that outputs a ggproto Position subclass object (e.g. ggplot2::position_identity()).}
+\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a \verb{position_*()} function that outputs a ggproto Position subclass object (e.g. \code{ggplot2::position_identity()}).}
 
-\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. ggplot2::coord_cartesian()).}
+\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. \code{\link[ggplot2:coord_cartesian]{ggplot2::coord_cartesian()}}).}
 
-\item{theme}{A ggplot2 theme (e.g. light_mode_b(), dark_mode_rt() or ggplot2::theme_grey()).}
+\item{theme}{A ggplot2 theme (e.g. \code{\link[=light_mode_b]{light_mode_b()}}, \code{\link[=dark_mode_rt]{dark_mode_rt()}} or \code{\link[ggplot2:ggtheme]{ggplot2::theme_grey()}}).}
 
-\item{x}{Unquoted x aesthetic variable.}
+\item{x}{Unquoted \code{x} aesthetic variable.}
 
-\item{xmin}{Unquoted xmin aesthetic variable.}
+\item{xmin}{Unquoted \code{xmin} aesthetic variable.}
 
-\item{xmax}{Unquoted xmax aesthetic variable.}
+\item{xmax}{Unquoted \code{xmax} aesthetic variable.}
 
-\item{xend}{Unquoted xend aesthetic variable.}
+\item{xend}{Unquoted \code{xend} aesthetic variable.}
 
-\item{y}{Unquoted y aesthetic variable.}
+\item{y}{Unquoted \code{y} aesthetic variable.}
 
-\item{ymin}{Unquoted ymin aesthetic variable.}
+\item{ymin}{Unquoted \code{ymin} aesthetic variable.}
 
-\item{ymax}{Unquoted ymax aesthetic variable.}
+\item{ymax}{Unquoted \code{ymax} aesthetic variable.}
 
-\item{yend}{Unquoted yend aesthetic variable.}
+\item{yend}{Unquoted \code{yend} aesthetic variable.}
 
-\item{z}{Unquoted z aesthetic variable.}
+\item{z}{Unquoted \code{z} aesthetic variable.}
 
-\item{col}{Unquoted col and fill aesthetic variable.}
+\item{col}{Unquoted \code{col} and \code{fill} aesthetic variable.}
 
-\item{alpha}{Unquoted alpha aesthetic variable.}
+\item{alpha}{Unquoted \code{alpha} aesthetic variable.}
 
-\item{facet}{Unquoted facet aesthetic variable.}
+\item{facet}{Unquoted \code{facet} aesthetic variable.}
 
 \item{facet2}{Unquoted second facet variable.}
 
-\item{group}{Unquoted group aesthetic variable.}
+\item{group}{Unquoted \code{group} aesthetic variable.}
 
-\item{subgroup}{Unquoted subgroup aesthetic variable.}
+\item{subgroup}{Unquoted \code{subgroup} aesthetic variable.}
 
-\item{label}{Unquoted label aesthetic variable.}
+\item{label}{Unquoted \code{label} aesthetic variable.}
 
-\item{text}{Unquoted text aesthetic variable.}
+\item{text}{Unquoted \code{text} aesthetic variable.}
 
-\item{sample}{Unquoted sample aesthetic variable.}
+\item{sample}{Unquoted \code{sample} aesthetic variable.}
 
-\item{mapping}{Set of additional aesthetic mappings within the ggplot2::aes function for non-supported aesthetics (e.g. shape, linetype, linewidth, or size) or for delayed evaluation.}
+\item{mapping}{Set of additional aesthetic mappings within \code{ggplot2::aes()} for non-supported aesthetics (e.g. \code{shape}, \code{linetype}, \code{linewidth}, or \code{size}) or for delayed evaluation.}
 
-\item{x_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{x_breaks, y_breaks}{A \verb{scales::breaks_*} function (e.g. \code{\link[scales:breaks_pretty]{scales::breaks_pretty()}}), or a vector of breaks.}
 
-\item{x_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{x_expand, y_expand}{Padding to the limits with the \code{ggplot2::expansion()} function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{x_expand_limits}{For a continuous x variable, any values that the limits should encompass (e.g. 0).}
+\item{x_expand_limits, y_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{x_gridlines}{TRUE or FALSE for vertical x gridlines. NULL guesses based on the classes of the x and y.}
+\item{x_gridlines}{\code{TRUE} or \code{FALSE} for vertical \code{x} gridlines. \code{NULL} guesses based on the classes of the x and y.}
 
-\item{x_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{x_labels, y_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{\link[scales:label_number]{scales::label_comma()}}), or a vector of labels.}
 
-\item{x_limits}{A vector of length 2 to determine the limits of the axis.}
+\item{x_limits, y_limits}{A vector of length 2 to determine the limits of the axis.}
 
-\item{x_oob}{For a continuous x variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{x_oob, y_oob}{For a continuous \code{x} variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
-\item{x_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
+\item{x_sec_axis, y_sec_axis}{A secondary axis using \code{ggplot2::sec_axis()} or \code{ggplot2::dup_axis()}.}
 
-\item{x_title}{Axis title string. Use "" for no title.}
+\item{x_title, y_title}{Axis title string. Use \code{""} for no title.}
 
-\item{x_transform}{For a numeric x variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{x_transform, y_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{y_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{y_gridlines}{\code{TRUE} or \code{FALSE} of horizontal \code{y} gridlines. \code{NULL} guesses based on the classes of the \code{x} and \code{y}.}
 
-\item{y_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
-
-\item{y_expand_limits}{For a continuous y variable, any values that the limits should encompass (e.g. 0).}
-
-\item{y_gridlines}{TRUE or FALSE of horizontal y gridlines. NULL guesses based on the classes of the x and y.}
-
-\item{y_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
-
-\item{y_limits}{A vector of length 2 to determine the limits of the axis.}
-
-\item{y_oob}{For a continuous y variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
-
-\item{y_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
-
-\item{y_title}{Axis title string. Use "" for no title.}
-
-\item{y_transform}{For a numeric y variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
-
-\item{col_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{col_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{col_continuous_type}{For a continuous variable, whether to colour as a "gradient" or in "steps". Defaults to "gradient".}
 
 \item{col_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{col_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{col_expand}{Padding to the limits with \code{ggplot2::expansion()}, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{col_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{col_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{col_legend_ncol}{The number of columns for the legend elements.}
+\item{col_legend_ncol, col_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{col_legend_nrow}{The number of rows for the legend elements.}
-
-\item{col_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{col_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{col_limits}{A vector to determine the limits of the scale.}
 
-\item{col_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{col_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{col_pal}{colours to use. A character vector of hex codes (or names).}
 
-\item{col_pal_na}{colour to use for NA values. A character vector of a hex code (or name).}
+\item{col_pal_na}{colour to use for \code{NA} values. A character vector of a hex code (or name).}
 
-\item{col_rescale}{For a continuous variable, a scales::rescale function.}
+\item{col_rescale}{For a continuous variable, a \code{scales::rescale} function.}
 
 \item{col_title}{Legend title string. Use "" for no title.}
 
-\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{alpha_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{alpha_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{alpha_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{alpha_legend_ncol}{The number of columns for the legend elements.}
+\item{alpha_legend_ncol, alpha_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{alpha_legend_nrow}{The number of rows for the legend elements.}
-
-\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{alpha_limits}{A vector to determine the limits of the scale.}
 
-\item{alpha_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{alpha_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{alpha_pal}{Alpha values to use as a numeric vector. For a continuous variable, a range is only needed.}
 
-\item{alpha_pal_na}{Alpha value to use for the NA value.}
+\item{alpha_pal_na}{Alpha value to use for the \code{NA} value.}
 
-\item{alpha_title}{Legend title string. Use "" for no title.}
+\item{alpha_title}{Legend title string. Use \code{""} for no title.}
 
-\item{alpha_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{alpha_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the transform_ prefix (e.g. "log10").}
 
 \item{facet_axes}{Whether to add interior axes and ticks with "margins", "all", "all_x", or "all_y".}
 
 \item{facet_axis_labels}{Whether to add interior axis labels with "margins", "all", "all_x", or "all_y".}
 
-\item{facet_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
+\item{facet_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
 
 \item{facet_labels_position}{When the facet layout is "wrap", the position of the facet labels. Either "top", "right", "bottom" or "left".}
 
 \item{facet_labels_switch}{When the facet layout is "grid", whether to switch the facet labels to the opposite side of the plot. Either "x", "y" or "both".}
 
-\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If NULL and a single facet (or facet2) argument is provided, then defaults to "wrap". If NULL and both facet and facet2 arguments are provided, defaults to "grid".}
+\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If \code{NULL} and a single \code{facet} (or \code{facet2}) argument is provided, then defaults to "wrap". If \code{NULL} and both facet and facet2 arguments are provided, defaults to "grid".}
 
 \item{facet_ncol}{The number of columns of facets. Only applies to a facet layout of "wrap".}
 
@@ -268,15 +246,15 @@ gg_density_2d(
 
 \item{caption}{Caption title string.}
 
-\item{titles}{A function to format unspecified titles. Defaults to snakecase::to_sentence_case.}
+\item{titles}{A function to format unspecified titles. Defaults to \code{snakecase::to_sentence_case}.}
 
-\item{flipped}{TRUE or FALSE or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
+\item{flipped}{\code{TRUE} or \code{FALSE} or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
 }
 \value{
 A ggplot object.
 }
 \description{
-Create a density_2d ggplot with a wrapper around ggplot() + geom_density_2d.
+Create a density_2d ggplot with a wrapper around \code{ggplot()} + \link[ggplot2:geom_density_2d]{geom_density_2d()}.
 }
 \examples{
 

--- a/man/gg_density_2d_filled.Rd
+++ b/man/gg_density_2d_filled.Rd
@@ -98,161 +98,139 @@ gg_density_2d_filled(
 \arguments{
 \item{data}{A data frame or tibble.}
 
-\item{...}{Other arguments passed to within a params list in the layer function.}
+\item{...}{Other arguments passed to within a \code{params} list in \code{layer()}.}
 
 \item{stat}{A statistical transformation to use on the data. A snakecase character string of a ggproto Stat subclass object minus the Stat prefix (e.g. "identity").}
 
-\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a position_* function that outputs a ggproto Position subclass object (e.g. ggplot2::position_identity()).}
+\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a \verb{position_*()} function that outputs a ggproto Position subclass object (e.g. \code{ggplot2::position_identity()}).}
 
-\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. ggplot2::coord_cartesian()).}
+\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. \code{\link[ggplot2:coord_cartesian]{ggplot2::coord_cartesian()}}).}
 
-\item{theme}{A ggplot2 theme (e.g. light_mode_b(), dark_mode_rt() or ggplot2::theme_grey()).}
+\item{theme}{A ggplot2 theme (e.g. \code{\link[=light_mode_b]{light_mode_b()}}, \code{\link[=dark_mode_rt]{dark_mode_rt()}} or \code{\link[ggplot2:ggtheme]{ggplot2::theme_grey()}}).}
 
-\item{x}{Unquoted x aesthetic variable.}
+\item{x}{Unquoted \code{x} aesthetic variable.}
 
-\item{xmin}{Unquoted xmin aesthetic variable.}
+\item{xmin}{Unquoted \code{xmin} aesthetic variable.}
 
-\item{xmax}{Unquoted xmax aesthetic variable.}
+\item{xmax}{Unquoted \code{xmax} aesthetic variable.}
 
-\item{xend}{Unquoted xend aesthetic variable.}
+\item{xend}{Unquoted \code{xend} aesthetic variable.}
 
-\item{y}{Unquoted y aesthetic variable.}
+\item{y}{Unquoted \code{y} aesthetic variable.}
 
-\item{ymin}{Unquoted ymin aesthetic variable.}
+\item{ymin}{Unquoted \code{ymin} aesthetic variable.}
 
-\item{ymax}{Unquoted ymax aesthetic variable.}
+\item{ymax}{Unquoted \code{ymax} aesthetic variable.}
 
-\item{yend}{Unquoted yend aesthetic variable.}
+\item{yend}{Unquoted \code{yend} aesthetic variable.}
 
-\item{z}{Unquoted z aesthetic variable.}
+\item{z}{Unquoted \code{z} aesthetic variable.}
 
-\item{col}{Unquoted col and fill aesthetic variable.}
+\item{col}{Unquoted \code{col} and \code{fill} aesthetic variable.}
 
-\item{alpha}{Unquoted alpha aesthetic variable.}
+\item{alpha}{Unquoted \code{alpha} aesthetic variable.}
 
-\item{facet}{Unquoted facet aesthetic variable.}
+\item{facet}{Unquoted \code{facet} aesthetic variable.}
 
 \item{facet2}{Unquoted second facet variable.}
 
-\item{group}{Unquoted group aesthetic variable.}
+\item{group}{Unquoted \code{group} aesthetic variable.}
 
-\item{subgroup}{Unquoted subgroup aesthetic variable.}
+\item{subgroup}{Unquoted \code{subgroup} aesthetic variable.}
 
-\item{label}{Unquoted label aesthetic variable.}
+\item{label}{Unquoted \code{label} aesthetic variable.}
 
-\item{text}{Unquoted text aesthetic variable.}
+\item{text}{Unquoted \code{text} aesthetic variable.}
 
-\item{sample}{Unquoted sample aesthetic variable.}
+\item{sample}{Unquoted \code{sample} aesthetic variable.}
 
-\item{mapping}{Set of additional aesthetic mappings within the ggplot2::aes function for non-supported aesthetics (e.g. shape, linetype, linewidth, or size) or for delayed evaluation.}
+\item{mapping}{Set of additional aesthetic mappings within \code{ggplot2::aes()} for non-supported aesthetics (e.g. \code{shape}, \code{linetype}, \code{linewidth}, or \code{size}) or for delayed evaluation.}
 
-\item{x_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{x_breaks, y_breaks}{A \verb{scales::breaks_*} function (e.g. \code{\link[scales:breaks_pretty]{scales::breaks_pretty()}}), or a vector of breaks.}
 
-\item{x_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{x_expand, y_expand}{Padding to the limits with the \code{ggplot2::expansion()} function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{x_expand_limits}{For a continuous x variable, any values that the limits should encompass (e.g. 0).}
+\item{x_expand_limits, y_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{x_gridlines}{TRUE or FALSE for vertical x gridlines. NULL guesses based on the classes of the x and y.}
+\item{x_gridlines}{\code{TRUE} or \code{FALSE} for vertical \code{x} gridlines. \code{NULL} guesses based on the classes of the x and y.}
 
-\item{x_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{x_labels, y_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{\link[scales:label_number]{scales::label_comma()}}), or a vector of labels.}
 
-\item{x_limits}{A vector of length 2 to determine the limits of the axis.}
+\item{x_limits, y_limits}{A vector of length 2 to determine the limits of the axis.}
 
-\item{x_oob}{For a continuous x variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{x_oob, y_oob}{For a continuous \code{x} variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
-\item{x_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
+\item{x_sec_axis, y_sec_axis}{A secondary axis using \code{ggplot2::sec_axis()} or \code{ggplot2::dup_axis()}.}
 
-\item{x_title}{Axis title string. Use "" for no title.}
+\item{x_title, y_title}{Axis title string. Use \code{""} for no title.}
 
-\item{x_transform}{For a numeric x variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{x_transform, y_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{y_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{y_gridlines}{\code{TRUE} or \code{FALSE} of horizontal \code{y} gridlines. \code{NULL} guesses based on the classes of the \code{x} and \code{y}.}
 
-\item{y_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
-
-\item{y_expand_limits}{For a continuous y variable, any values that the limits should encompass (e.g. 0).}
-
-\item{y_gridlines}{TRUE or FALSE of horizontal y gridlines. NULL guesses based on the classes of the x and y.}
-
-\item{y_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
-
-\item{y_limits}{A vector of length 2 to determine the limits of the axis.}
-
-\item{y_oob}{For a continuous y variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
-
-\item{y_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
-
-\item{y_title}{Axis title string. Use "" for no title.}
-
-\item{y_transform}{For a numeric y variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
-
-\item{col_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{col_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{col_continuous_type}{For a continuous variable, whether to colour as a "gradient" or in "steps". Defaults to "gradient".}
 
 \item{col_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{col_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{col_expand}{Padding to the limits with \code{ggplot2::expansion()}, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{col_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{col_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{col_legend_ncol}{The number of columns for the legend elements.}
+\item{col_legend_ncol, col_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{col_legend_nrow}{The number of rows for the legend elements.}
-
-\item{col_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{col_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{col_limits}{A vector to determine the limits of the scale.}
 
-\item{col_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{col_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{col_pal}{colours to use. A character vector of hex codes (or names).}
 
-\item{col_pal_na}{colour to use for NA values. A character vector of a hex code (or name).}
+\item{col_pal_na}{colour to use for \code{NA} values. A character vector of a hex code (or name).}
 
-\item{col_rescale}{For a continuous variable, a scales::rescale function.}
+\item{col_rescale}{For a continuous variable, a \code{scales::rescale} function.}
 
 \item{col_title}{Legend title string. Use "" for no title.}
 
-\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{alpha_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{alpha_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{alpha_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{alpha_legend_ncol}{The number of columns for the legend elements.}
+\item{alpha_legend_ncol, alpha_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{alpha_legend_nrow}{The number of rows for the legend elements.}
-
-\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{alpha_limits}{A vector to determine the limits of the scale.}
 
-\item{alpha_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{alpha_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{alpha_pal}{Alpha values to use as a numeric vector. For a continuous variable, a range is only needed.}
 
-\item{alpha_pal_na}{Alpha value to use for the NA value.}
+\item{alpha_pal_na}{Alpha value to use for the \code{NA} value.}
 
-\item{alpha_title}{Legend title string. Use "" for no title.}
+\item{alpha_title}{Legend title string. Use \code{""} for no title.}
 
-\item{alpha_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{alpha_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the transform_ prefix (e.g. "log10").}
 
 \item{facet_axes}{Whether to add interior axes and ticks with "margins", "all", "all_x", or "all_y".}
 
 \item{facet_axis_labels}{Whether to add interior axis labels with "margins", "all", "all_x", or "all_y".}
 
-\item{facet_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
+\item{facet_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
 
 \item{facet_labels_position}{When the facet layout is "wrap", the position of the facet labels. Either "top", "right", "bottom" or "left".}
 
 \item{facet_labels_switch}{When the facet layout is "grid", whether to switch the facet labels to the opposite side of the plot. Either "x", "y" or "both".}
 
-\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If NULL and a single facet (or facet2) argument is provided, then defaults to "wrap". If NULL and both facet and facet2 arguments are provided, defaults to "grid".}
+\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If \code{NULL} and a single \code{facet} (or \code{facet2}) argument is provided, then defaults to "wrap". If \code{NULL} and both facet and facet2 arguments are provided, defaults to "grid".}
 
 \item{facet_ncol}{The number of columns of facets. Only applies to a facet layout of "wrap".}
 
@@ -268,15 +246,15 @@ gg_density_2d_filled(
 
 \item{caption}{Caption title string.}
 
-\item{titles}{A function to format unspecified titles. Defaults to snakecase::to_sentence_case.}
+\item{titles}{A function to format unspecified titles. Defaults to \code{snakecase::to_sentence_case}.}
 
-\item{flipped}{TRUE or FALSE or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
+\item{flipped}{\code{TRUE} or \code{FALSE} or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
 }
 \value{
 A ggplot object.
 }
 \description{
-Create a density_2d_filled ggplot with a wrapper around ggplot() + geom_density_2d_filled.
+Create a density_2d_filled ggplot with a wrapper around \code{ggplot()} + \link[ggplot2:geom_density_2d]{geom_density_2d_filled()}.
 }
 \examples{
 

--- a/man/gg_errorbar.Rd
+++ b/man/gg_errorbar.Rd
@@ -98,161 +98,139 @@ gg_errorbar(
 \arguments{
 \item{data}{A data frame or tibble.}
 
-\item{...}{Other arguments passed to within a params list in the layer function.}
+\item{...}{Other arguments passed to within a \code{params} list in \code{layer()}.}
 
 \item{stat}{A statistical transformation to use on the data. A snakecase character string of a ggproto Stat subclass object minus the Stat prefix (e.g. "identity").}
 
-\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a position_* function that outputs a ggproto Position subclass object (e.g. ggplot2::position_identity()).}
+\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a \verb{position_*()} function that outputs a ggproto Position subclass object (e.g. \code{ggplot2::position_identity()}).}
 
-\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. ggplot2::coord_cartesian()).}
+\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. \code{\link[ggplot2:coord_cartesian]{ggplot2::coord_cartesian()}}).}
 
-\item{theme}{A ggplot2 theme (e.g. light_mode_b(), dark_mode_rt() or ggplot2::theme_grey()).}
+\item{theme}{A ggplot2 theme (e.g. \code{\link[=light_mode_b]{light_mode_b()}}, \code{\link[=dark_mode_rt]{dark_mode_rt()}} or \code{\link[ggplot2:ggtheme]{ggplot2::theme_grey()}}).}
 
-\item{x}{Unquoted x aesthetic variable.}
+\item{x}{Unquoted \code{x} aesthetic variable.}
 
-\item{xmin}{Unquoted xmin aesthetic variable.}
+\item{xmin}{Unquoted \code{xmin} aesthetic variable.}
 
-\item{xmax}{Unquoted xmax aesthetic variable.}
+\item{xmax}{Unquoted \code{xmax} aesthetic variable.}
 
-\item{xend}{Unquoted xend aesthetic variable.}
+\item{xend}{Unquoted \code{xend} aesthetic variable.}
 
-\item{y}{Unquoted y aesthetic variable.}
+\item{y}{Unquoted \code{y} aesthetic variable.}
 
-\item{ymin}{Unquoted ymin aesthetic variable.}
+\item{ymin}{Unquoted \code{ymin} aesthetic variable.}
 
-\item{ymax}{Unquoted ymax aesthetic variable.}
+\item{ymax}{Unquoted \code{ymax} aesthetic variable.}
 
-\item{yend}{Unquoted yend aesthetic variable.}
+\item{yend}{Unquoted \code{yend} aesthetic variable.}
 
-\item{z}{Unquoted z aesthetic variable.}
+\item{z}{Unquoted \code{z} aesthetic variable.}
 
-\item{col}{Unquoted col and fill aesthetic variable.}
+\item{col}{Unquoted \code{col} and \code{fill} aesthetic variable.}
 
-\item{alpha}{Unquoted alpha aesthetic variable.}
+\item{alpha}{Unquoted \code{alpha} aesthetic variable.}
 
-\item{facet}{Unquoted facet aesthetic variable.}
+\item{facet}{Unquoted \code{facet} aesthetic variable.}
 
 \item{facet2}{Unquoted second facet variable.}
 
-\item{group}{Unquoted group aesthetic variable.}
+\item{group}{Unquoted \code{group} aesthetic variable.}
 
-\item{subgroup}{Unquoted subgroup aesthetic variable.}
+\item{subgroup}{Unquoted \code{subgroup} aesthetic variable.}
 
-\item{label}{Unquoted label aesthetic variable.}
+\item{label}{Unquoted \code{label} aesthetic variable.}
 
-\item{text}{Unquoted text aesthetic variable.}
+\item{text}{Unquoted \code{text} aesthetic variable.}
 
-\item{sample}{Unquoted sample aesthetic variable.}
+\item{sample}{Unquoted \code{sample} aesthetic variable.}
 
-\item{mapping}{Set of additional aesthetic mappings within the ggplot2::aes function for non-supported aesthetics (e.g. shape, linetype, linewidth, or size) or for delayed evaluation.}
+\item{mapping}{Set of additional aesthetic mappings within \code{ggplot2::aes()} for non-supported aesthetics (e.g. \code{shape}, \code{linetype}, \code{linewidth}, or \code{size}) or for delayed evaluation.}
 
-\item{x_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{x_breaks, y_breaks}{A \verb{scales::breaks_*} function (e.g. \code{\link[scales:breaks_pretty]{scales::breaks_pretty()}}), or a vector of breaks.}
 
-\item{x_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{x_expand, y_expand}{Padding to the limits with the \code{ggplot2::expansion()} function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{x_expand_limits}{For a continuous x variable, any values that the limits should encompass (e.g. 0).}
+\item{x_expand_limits, y_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{x_gridlines}{TRUE or FALSE for vertical x gridlines. NULL guesses based on the classes of the x and y.}
+\item{x_gridlines}{\code{TRUE} or \code{FALSE} for vertical \code{x} gridlines. \code{NULL} guesses based on the classes of the x and y.}
 
-\item{x_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{x_labels, y_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{\link[scales:label_number]{scales::label_comma()}}), or a vector of labels.}
 
-\item{x_limits}{A vector of length 2 to determine the limits of the axis.}
+\item{x_limits, y_limits}{A vector of length 2 to determine the limits of the axis.}
 
-\item{x_oob}{For a continuous x variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{x_oob, y_oob}{For a continuous \code{x} variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
-\item{x_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
+\item{x_sec_axis, y_sec_axis}{A secondary axis using \code{ggplot2::sec_axis()} or \code{ggplot2::dup_axis()}.}
 
-\item{x_title}{Axis title string. Use "" for no title.}
+\item{x_title, y_title}{Axis title string. Use \code{""} for no title.}
 
-\item{x_transform}{For a numeric x variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{x_transform, y_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{y_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{y_gridlines}{\code{TRUE} or \code{FALSE} of horizontal \code{y} gridlines. \code{NULL} guesses based on the classes of the \code{x} and \code{y}.}
 
-\item{y_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
-
-\item{y_expand_limits}{For a continuous y variable, any values that the limits should encompass (e.g. 0).}
-
-\item{y_gridlines}{TRUE or FALSE of horizontal y gridlines. NULL guesses based on the classes of the x and y.}
-
-\item{y_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
-
-\item{y_limits}{A vector of length 2 to determine the limits of the axis.}
-
-\item{y_oob}{For a continuous y variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
-
-\item{y_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
-
-\item{y_title}{Axis title string. Use "" for no title.}
-
-\item{y_transform}{For a numeric y variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
-
-\item{col_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{col_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{col_continuous_type}{For a continuous variable, whether to colour as a "gradient" or in "steps". Defaults to "gradient".}
 
 \item{col_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{col_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{col_expand}{Padding to the limits with \code{ggplot2::expansion()}, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{col_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{col_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{col_legend_ncol}{The number of columns for the legend elements.}
+\item{col_legend_ncol, col_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{col_legend_nrow}{The number of rows for the legend elements.}
-
-\item{col_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{col_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{col_limits}{A vector to determine the limits of the scale.}
 
-\item{col_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{col_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{col_pal}{colours to use. A character vector of hex codes (or names).}
 
-\item{col_pal_na}{colour to use for NA values. A character vector of a hex code (or name).}
+\item{col_pal_na}{colour to use for \code{NA} values. A character vector of a hex code (or name).}
 
-\item{col_rescale}{For a continuous variable, a scales::rescale function.}
+\item{col_rescale}{For a continuous variable, a \code{scales::rescale} function.}
 
 \item{col_title}{Legend title string. Use "" for no title.}
 
-\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{alpha_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{alpha_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{alpha_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{alpha_legend_ncol}{The number of columns for the legend elements.}
+\item{alpha_legend_ncol, alpha_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{alpha_legend_nrow}{The number of rows for the legend elements.}
-
-\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{alpha_limits}{A vector to determine the limits of the scale.}
 
-\item{alpha_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{alpha_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{alpha_pal}{Alpha values to use as a numeric vector. For a continuous variable, a range is only needed.}
 
-\item{alpha_pal_na}{Alpha value to use for the NA value.}
+\item{alpha_pal_na}{Alpha value to use for the \code{NA} value.}
 
-\item{alpha_title}{Legend title string. Use "" for no title.}
+\item{alpha_title}{Legend title string. Use \code{""} for no title.}
 
-\item{alpha_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{alpha_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the transform_ prefix (e.g. "log10").}
 
 \item{facet_axes}{Whether to add interior axes and ticks with "margins", "all", "all_x", or "all_y".}
 
 \item{facet_axis_labels}{Whether to add interior axis labels with "margins", "all", "all_x", or "all_y".}
 
-\item{facet_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
+\item{facet_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
 
 \item{facet_labels_position}{When the facet layout is "wrap", the position of the facet labels. Either "top", "right", "bottom" or "left".}
 
 \item{facet_labels_switch}{When the facet layout is "grid", whether to switch the facet labels to the opposite side of the plot. Either "x", "y" or "both".}
 
-\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If NULL and a single facet (or facet2) argument is provided, then defaults to "wrap". If NULL and both facet and facet2 arguments are provided, defaults to "grid".}
+\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If \code{NULL} and a single \code{facet} (or \code{facet2}) argument is provided, then defaults to "wrap". If \code{NULL} and both facet and facet2 arguments are provided, defaults to "grid".}
 
 \item{facet_ncol}{The number of columns of facets. Only applies to a facet layout of "wrap".}
 
@@ -268,15 +246,15 @@ gg_errorbar(
 
 \item{caption}{Caption title string.}
 
-\item{titles}{A function to format unspecified titles. Defaults to snakecase::to_sentence_case.}
+\item{titles}{A function to format unspecified titles. Defaults to \code{snakecase::to_sentence_case}.}
 
-\item{flipped}{TRUE or FALSE or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
+\item{flipped}{\code{TRUE} or \code{FALSE} or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
 }
 \value{
 A ggplot object.
 }
 \description{
-Create a errorbar ggplot with a wrapper around ggplot() + geom_errorbar.
+Create a errorbar ggplot with a wrapper around \code{ggplot()} + \link[ggplot2:geom_linerange]{geom_errorbar()}.
 }
 \examples{
 

--- a/man/gg_freqpoly.Rd
+++ b/man/gg_freqpoly.Rd
@@ -98,161 +98,139 @@ gg_freqpoly(
 \arguments{
 \item{data}{A data frame or tibble.}
 
-\item{...}{Other arguments passed to within a params list in the layer function.}
+\item{...}{Other arguments passed to within a \code{params} list in \code{layer()}.}
 
 \item{stat}{A statistical transformation to use on the data. A snakecase character string of a ggproto Stat subclass object minus the Stat prefix (e.g. "identity").}
 
-\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a position_* function that outputs a ggproto Position subclass object (e.g. ggplot2::position_identity()).}
+\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a \verb{position_*()} function that outputs a ggproto Position subclass object (e.g. \code{ggplot2::position_identity()}).}
 
-\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. ggplot2::coord_cartesian()).}
+\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. \code{\link[ggplot2:coord_cartesian]{ggplot2::coord_cartesian()}}).}
 
-\item{theme}{A ggplot2 theme (e.g. light_mode_b(), dark_mode_rt() or ggplot2::theme_grey()).}
+\item{theme}{A ggplot2 theme (e.g. \code{\link[=light_mode_b]{light_mode_b()}}, \code{\link[=dark_mode_rt]{dark_mode_rt()}} or \code{\link[ggplot2:ggtheme]{ggplot2::theme_grey()}}).}
 
-\item{x}{Unquoted x aesthetic variable.}
+\item{x}{Unquoted \code{x} aesthetic variable.}
 
-\item{xmin}{Unquoted xmin aesthetic variable.}
+\item{xmin}{Unquoted \code{xmin} aesthetic variable.}
 
-\item{xmax}{Unquoted xmax aesthetic variable.}
+\item{xmax}{Unquoted \code{xmax} aesthetic variable.}
 
-\item{xend}{Unquoted xend aesthetic variable.}
+\item{xend}{Unquoted \code{xend} aesthetic variable.}
 
-\item{y}{Unquoted y aesthetic variable.}
+\item{y}{Unquoted \code{y} aesthetic variable.}
 
-\item{ymin}{Unquoted ymin aesthetic variable.}
+\item{ymin}{Unquoted \code{ymin} aesthetic variable.}
 
-\item{ymax}{Unquoted ymax aesthetic variable.}
+\item{ymax}{Unquoted \code{ymax} aesthetic variable.}
 
-\item{yend}{Unquoted yend aesthetic variable.}
+\item{yend}{Unquoted \code{yend} aesthetic variable.}
 
-\item{z}{Unquoted z aesthetic variable.}
+\item{z}{Unquoted \code{z} aesthetic variable.}
 
-\item{col}{Unquoted col and fill aesthetic variable.}
+\item{col}{Unquoted \code{col} and \code{fill} aesthetic variable.}
 
-\item{alpha}{Unquoted alpha aesthetic variable.}
+\item{alpha}{Unquoted \code{alpha} aesthetic variable.}
 
-\item{facet}{Unquoted facet aesthetic variable.}
+\item{facet}{Unquoted \code{facet} aesthetic variable.}
 
 \item{facet2}{Unquoted second facet variable.}
 
-\item{group}{Unquoted group aesthetic variable.}
+\item{group}{Unquoted \code{group} aesthetic variable.}
 
-\item{subgroup}{Unquoted subgroup aesthetic variable.}
+\item{subgroup}{Unquoted \code{subgroup} aesthetic variable.}
 
-\item{label}{Unquoted label aesthetic variable.}
+\item{label}{Unquoted \code{label} aesthetic variable.}
 
-\item{text}{Unquoted text aesthetic variable.}
+\item{text}{Unquoted \code{text} aesthetic variable.}
 
-\item{sample}{Unquoted sample aesthetic variable.}
+\item{sample}{Unquoted \code{sample} aesthetic variable.}
 
-\item{mapping}{Set of additional aesthetic mappings within the ggplot2::aes function for non-supported aesthetics (e.g. shape, linetype, linewidth, or size) or for delayed evaluation.}
+\item{mapping}{Set of additional aesthetic mappings within \code{ggplot2::aes()} for non-supported aesthetics (e.g. \code{shape}, \code{linetype}, \code{linewidth}, or \code{size}) or for delayed evaluation.}
 
-\item{x_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{x_breaks, y_breaks}{A \verb{scales::breaks_*} function (e.g. \code{\link[scales:breaks_pretty]{scales::breaks_pretty()}}), or a vector of breaks.}
 
-\item{x_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{x_expand, y_expand}{Padding to the limits with the \code{ggplot2::expansion()} function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{x_expand_limits}{For a continuous x variable, any values that the limits should encompass (e.g. 0).}
+\item{x_expand_limits, y_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{x_gridlines}{TRUE or FALSE for vertical x gridlines. NULL guesses based on the classes of the x and y.}
+\item{x_gridlines}{\code{TRUE} or \code{FALSE} for vertical \code{x} gridlines. \code{NULL} guesses based on the classes of the x and y.}
 
-\item{x_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{x_labels, y_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{\link[scales:label_number]{scales::label_comma()}}), or a vector of labels.}
 
-\item{x_limits}{A vector of length 2 to determine the limits of the axis.}
+\item{x_limits, y_limits}{A vector of length 2 to determine the limits of the axis.}
 
-\item{x_oob}{For a continuous x variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{x_oob, y_oob}{For a continuous \code{x} variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
-\item{x_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
+\item{x_sec_axis, y_sec_axis}{A secondary axis using \code{ggplot2::sec_axis()} or \code{ggplot2::dup_axis()}.}
 
-\item{x_title}{Axis title string. Use "" for no title.}
+\item{x_title, y_title}{Axis title string. Use \code{""} for no title.}
 
-\item{x_transform}{For a numeric x variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{x_transform, y_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{y_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{y_gridlines}{\code{TRUE} or \code{FALSE} of horizontal \code{y} gridlines. \code{NULL} guesses based on the classes of the \code{x} and \code{y}.}
 
-\item{y_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
-
-\item{y_expand_limits}{For a continuous y variable, any values that the limits should encompass (e.g. 0).}
-
-\item{y_gridlines}{TRUE or FALSE of horizontal y gridlines. NULL guesses based on the classes of the x and y.}
-
-\item{y_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
-
-\item{y_limits}{A vector of length 2 to determine the limits of the axis.}
-
-\item{y_oob}{For a continuous y variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
-
-\item{y_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
-
-\item{y_title}{Axis title string. Use "" for no title.}
-
-\item{y_transform}{For a numeric y variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
-
-\item{col_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{col_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{col_continuous_type}{For a continuous variable, whether to colour as a "gradient" or in "steps". Defaults to "gradient".}
 
 \item{col_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{col_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{col_expand}{Padding to the limits with \code{ggplot2::expansion()}, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{col_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{col_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{col_legend_ncol}{The number of columns for the legend elements.}
+\item{col_legend_ncol, col_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{col_legend_nrow}{The number of rows for the legend elements.}
-
-\item{col_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{col_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{col_limits}{A vector to determine the limits of the scale.}
 
-\item{col_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{col_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{col_pal}{colours to use. A character vector of hex codes (or names).}
 
-\item{col_pal_na}{colour to use for NA values. A character vector of a hex code (or name).}
+\item{col_pal_na}{colour to use for \code{NA} values. A character vector of a hex code (or name).}
 
-\item{col_rescale}{For a continuous variable, a scales::rescale function.}
+\item{col_rescale}{For a continuous variable, a \code{scales::rescale} function.}
 
 \item{col_title}{Legend title string. Use "" for no title.}
 
-\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{alpha_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{alpha_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{alpha_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{alpha_legend_ncol}{The number of columns for the legend elements.}
+\item{alpha_legend_ncol, alpha_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{alpha_legend_nrow}{The number of rows for the legend elements.}
-
-\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{alpha_limits}{A vector to determine the limits of the scale.}
 
-\item{alpha_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{alpha_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{alpha_pal}{Alpha values to use as a numeric vector. For a continuous variable, a range is only needed.}
 
-\item{alpha_pal_na}{Alpha value to use for the NA value.}
+\item{alpha_pal_na}{Alpha value to use for the \code{NA} value.}
 
-\item{alpha_title}{Legend title string. Use "" for no title.}
+\item{alpha_title}{Legend title string. Use \code{""} for no title.}
 
-\item{alpha_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{alpha_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the transform_ prefix (e.g. "log10").}
 
 \item{facet_axes}{Whether to add interior axes and ticks with "margins", "all", "all_x", or "all_y".}
 
 \item{facet_axis_labels}{Whether to add interior axis labels with "margins", "all", "all_x", or "all_y".}
 
-\item{facet_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
+\item{facet_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
 
 \item{facet_labels_position}{When the facet layout is "wrap", the position of the facet labels. Either "top", "right", "bottom" or "left".}
 
 \item{facet_labels_switch}{When the facet layout is "grid", whether to switch the facet labels to the opposite side of the plot. Either "x", "y" or "both".}
 
-\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If NULL and a single facet (or facet2) argument is provided, then defaults to "wrap". If NULL and both facet and facet2 arguments are provided, defaults to "grid".}
+\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If \code{NULL} and a single \code{facet} (or \code{facet2}) argument is provided, then defaults to "wrap". If \code{NULL} and both facet and facet2 arguments are provided, defaults to "grid".}
 
 \item{facet_ncol}{The number of columns of facets. Only applies to a facet layout of "wrap".}
 
@@ -268,15 +246,15 @@ gg_freqpoly(
 
 \item{caption}{Caption title string.}
 
-\item{titles}{A function to format unspecified titles. Defaults to snakecase::to_sentence_case.}
+\item{titles}{A function to format unspecified titles. Defaults to \code{snakecase::to_sentence_case}.}
 
-\item{flipped}{TRUE or FALSE or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
+\item{flipped}{\code{TRUE} or \code{FALSE} or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
 }
 \value{
 A ggplot object.
 }
 \description{
-Create a freqpoly ggplot with a wrapper around ggplot() + geom_freqpoly.
+Create a freqpoly ggplot with a wrapper around \code{ggplot()} + \link[ggplot2:geom_histogram]{geom_freqpoly()}.
 }
 \examples{
 

--- a/man/gg_function.Rd
+++ b/man/gg_function.Rd
@@ -98,161 +98,139 @@ gg_function(
 \arguments{
 \item{data}{A data frame or tibble.}
 
-\item{...}{Other arguments passed to within a params list in the layer function.}
+\item{...}{Other arguments passed to within a \code{params} list in \code{layer()}.}
 
 \item{stat}{A statistical transformation to use on the data. A snakecase character string of a ggproto Stat subclass object minus the Stat prefix (e.g. "identity").}
 
-\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a position_* function that outputs a ggproto Position subclass object (e.g. ggplot2::position_identity()).}
+\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a \verb{position_*()} function that outputs a ggproto Position subclass object (e.g. \code{ggplot2::position_identity()}).}
 
-\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. ggplot2::coord_cartesian()).}
+\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. \code{\link[ggplot2:coord_cartesian]{ggplot2::coord_cartesian()}}).}
 
-\item{theme}{A ggplot2 theme (e.g. light_mode_b(), dark_mode_rt() or ggplot2::theme_grey()).}
+\item{theme}{A ggplot2 theme (e.g. \code{\link[=light_mode_b]{light_mode_b()}}, \code{\link[=dark_mode_rt]{dark_mode_rt()}} or \code{\link[ggplot2:ggtheme]{ggplot2::theme_grey()}}).}
 
-\item{x}{Unquoted x aesthetic variable.}
+\item{x}{Unquoted \code{x} aesthetic variable.}
 
-\item{xmin}{Unquoted xmin aesthetic variable.}
+\item{xmin}{Unquoted \code{xmin} aesthetic variable.}
 
-\item{xmax}{Unquoted xmax aesthetic variable.}
+\item{xmax}{Unquoted \code{xmax} aesthetic variable.}
 
-\item{xend}{Unquoted xend aesthetic variable.}
+\item{xend}{Unquoted \code{xend} aesthetic variable.}
 
-\item{y}{Unquoted y aesthetic variable.}
+\item{y}{Unquoted \code{y} aesthetic variable.}
 
-\item{ymin}{Unquoted ymin aesthetic variable.}
+\item{ymin}{Unquoted \code{ymin} aesthetic variable.}
 
-\item{ymax}{Unquoted ymax aesthetic variable.}
+\item{ymax}{Unquoted \code{ymax} aesthetic variable.}
 
-\item{yend}{Unquoted yend aesthetic variable.}
+\item{yend}{Unquoted \code{yend} aesthetic variable.}
 
-\item{z}{Unquoted z aesthetic variable.}
+\item{z}{Unquoted \code{z} aesthetic variable.}
 
-\item{col}{Unquoted col and fill aesthetic variable.}
+\item{col}{Unquoted \code{col} and \code{fill} aesthetic variable.}
 
-\item{alpha}{Unquoted alpha aesthetic variable.}
+\item{alpha}{Unquoted \code{alpha} aesthetic variable.}
 
-\item{facet}{Unquoted facet aesthetic variable.}
+\item{facet}{Unquoted \code{facet} aesthetic variable.}
 
 \item{facet2}{Unquoted second facet variable.}
 
-\item{group}{Unquoted group aesthetic variable.}
+\item{group}{Unquoted \code{group} aesthetic variable.}
 
-\item{subgroup}{Unquoted subgroup aesthetic variable.}
+\item{subgroup}{Unquoted \code{subgroup} aesthetic variable.}
 
-\item{label}{Unquoted label aesthetic variable.}
+\item{label}{Unquoted \code{label} aesthetic variable.}
 
-\item{text}{Unquoted text aesthetic variable.}
+\item{text}{Unquoted \code{text} aesthetic variable.}
 
-\item{sample}{Unquoted sample aesthetic variable.}
+\item{sample}{Unquoted \code{sample} aesthetic variable.}
 
-\item{mapping}{Set of additional aesthetic mappings within the ggplot2::aes function for non-supported aesthetics (e.g. shape, linetype, linewidth, or size) or for delayed evaluation.}
+\item{mapping}{Set of additional aesthetic mappings within \code{ggplot2::aes()} for non-supported aesthetics (e.g. \code{shape}, \code{linetype}, \code{linewidth}, or \code{size}) or for delayed evaluation.}
 
-\item{x_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{x_breaks, y_breaks}{A \verb{scales::breaks_*} function (e.g. \code{\link[scales:breaks_pretty]{scales::breaks_pretty()}}), or a vector of breaks.}
 
-\item{x_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{x_expand, y_expand}{Padding to the limits with the \code{ggplot2::expansion()} function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{x_expand_limits}{For a continuous x variable, any values that the limits should encompass (e.g. 0).}
+\item{x_expand_limits, y_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{x_gridlines}{TRUE or FALSE for vertical x gridlines. NULL guesses based on the classes of the x and y.}
+\item{x_gridlines}{\code{TRUE} or \code{FALSE} for vertical \code{x} gridlines. \code{NULL} guesses based on the classes of the x and y.}
 
-\item{x_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{x_labels, y_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{\link[scales:label_number]{scales::label_comma()}}), or a vector of labels.}
 
-\item{x_limits}{A vector of length 2 to determine the limits of the axis.}
+\item{x_limits, y_limits}{A vector of length 2 to determine the limits of the axis.}
 
-\item{x_oob}{For a continuous x variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{x_oob, y_oob}{For a continuous \code{x} variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
-\item{x_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
+\item{x_sec_axis, y_sec_axis}{A secondary axis using \code{ggplot2::sec_axis()} or \code{ggplot2::dup_axis()}.}
 
-\item{x_title}{Axis title string. Use "" for no title.}
+\item{x_title, y_title}{Axis title string. Use \code{""} for no title.}
 
-\item{x_transform}{For a numeric x variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{x_transform, y_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{y_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{y_gridlines}{\code{TRUE} or \code{FALSE} of horizontal \code{y} gridlines. \code{NULL} guesses based on the classes of the \code{x} and \code{y}.}
 
-\item{y_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
-
-\item{y_expand_limits}{For a continuous y variable, any values that the limits should encompass (e.g. 0).}
-
-\item{y_gridlines}{TRUE or FALSE of horizontal y gridlines. NULL guesses based on the classes of the x and y.}
-
-\item{y_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
-
-\item{y_limits}{A vector of length 2 to determine the limits of the axis.}
-
-\item{y_oob}{For a continuous y variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
-
-\item{y_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
-
-\item{y_title}{Axis title string. Use "" for no title.}
-
-\item{y_transform}{For a numeric y variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
-
-\item{col_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{col_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{col_continuous_type}{For a continuous variable, whether to colour as a "gradient" or in "steps". Defaults to "gradient".}
 
 \item{col_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{col_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{col_expand}{Padding to the limits with \code{ggplot2::expansion()}, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{col_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{col_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{col_legend_ncol}{The number of columns for the legend elements.}
+\item{col_legend_ncol, col_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{col_legend_nrow}{The number of rows for the legend elements.}
-
-\item{col_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{col_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{col_limits}{A vector to determine the limits of the scale.}
 
-\item{col_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{col_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{col_pal}{colours to use. A character vector of hex codes (or names).}
 
-\item{col_pal_na}{colour to use for NA values. A character vector of a hex code (or name).}
+\item{col_pal_na}{colour to use for \code{NA} values. A character vector of a hex code (or name).}
 
-\item{col_rescale}{For a continuous variable, a scales::rescale function.}
+\item{col_rescale}{For a continuous variable, a \code{scales::rescale} function.}
 
 \item{col_title}{Legend title string. Use "" for no title.}
 
-\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{alpha_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{alpha_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{alpha_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{alpha_legend_ncol}{The number of columns for the legend elements.}
+\item{alpha_legend_ncol, alpha_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{alpha_legend_nrow}{The number of rows for the legend elements.}
-
-\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{alpha_limits}{A vector to determine the limits of the scale.}
 
-\item{alpha_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{alpha_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{alpha_pal}{Alpha values to use as a numeric vector. For a continuous variable, a range is only needed.}
 
-\item{alpha_pal_na}{Alpha value to use for the NA value.}
+\item{alpha_pal_na}{Alpha value to use for the \code{NA} value.}
 
-\item{alpha_title}{Legend title string. Use "" for no title.}
+\item{alpha_title}{Legend title string. Use \code{""} for no title.}
 
-\item{alpha_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{alpha_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the transform_ prefix (e.g. "log10").}
 
 \item{facet_axes}{Whether to add interior axes and ticks with "margins", "all", "all_x", or "all_y".}
 
 \item{facet_axis_labels}{Whether to add interior axis labels with "margins", "all", "all_x", or "all_y".}
 
-\item{facet_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
+\item{facet_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
 
 \item{facet_labels_position}{When the facet layout is "wrap", the position of the facet labels. Either "top", "right", "bottom" or "left".}
 
 \item{facet_labels_switch}{When the facet layout is "grid", whether to switch the facet labels to the opposite side of the plot. Either "x", "y" or "both".}
 
-\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If NULL and a single facet (or facet2) argument is provided, then defaults to "wrap". If NULL and both facet and facet2 arguments are provided, defaults to "grid".}
+\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If \code{NULL} and a single \code{facet} (or \code{facet2}) argument is provided, then defaults to "wrap". If \code{NULL} and both facet and facet2 arguments are provided, defaults to "grid".}
 
 \item{facet_ncol}{The number of columns of facets. Only applies to a facet layout of "wrap".}
 
@@ -268,15 +246,15 @@ gg_function(
 
 \item{caption}{Caption title string.}
 
-\item{titles}{A function to format unspecified titles. Defaults to snakecase::to_sentence_case.}
+\item{titles}{A function to format unspecified titles. Defaults to \code{snakecase::to_sentence_case}.}
 
-\item{flipped}{TRUE or FALSE or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
+\item{flipped}{\code{TRUE} or \code{FALSE} or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
 }
 \value{
 A ggplot object.
 }
 \description{
-Create a function ggplot with a wrapper around ggplot() + geom_function.
+Create a function ggplot with a wrapper around \code{ggplot()} + \link[ggplot2:geom_function]{geom_function()}.
 }
 \examples{
 

--- a/man/gg_hex.Rd
+++ b/man/gg_hex.Rd
@@ -98,161 +98,139 @@ gg_hex(
 \arguments{
 \item{data}{A data frame or tibble.}
 
-\item{...}{Other arguments passed to within a params list in the layer function.}
+\item{...}{Other arguments passed to within a \code{params} list in \code{layer()}.}
 
 \item{stat}{A statistical transformation to use on the data. A snakecase character string of a ggproto Stat subclass object minus the Stat prefix (e.g. "identity").}
 
-\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a position_* function that outputs a ggproto Position subclass object (e.g. ggplot2::position_identity()).}
+\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a \verb{position_*()} function that outputs a ggproto Position subclass object (e.g. \code{ggplot2::position_identity()}).}
 
-\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. ggplot2::coord_cartesian()).}
+\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. \code{\link[ggplot2:coord_cartesian]{ggplot2::coord_cartesian()}}).}
 
-\item{theme}{A ggplot2 theme (e.g. light_mode_b(), dark_mode_rt() or ggplot2::theme_grey()).}
+\item{theme}{A ggplot2 theme (e.g. \code{\link[=light_mode_b]{light_mode_b()}}, \code{\link[=dark_mode_rt]{dark_mode_rt()}} or \code{\link[ggplot2:ggtheme]{ggplot2::theme_grey()}}).}
 
-\item{x}{Unquoted x aesthetic variable.}
+\item{x}{Unquoted \code{x} aesthetic variable.}
 
-\item{xmin}{Unquoted xmin aesthetic variable.}
+\item{xmin}{Unquoted \code{xmin} aesthetic variable.}
 
-\item{xmax}{Unquoted xmax aesthetic variable.}
+\item{xmax}{Unquoted \code{xmax} aesthetic variable.}
 
-\item{xend}{Unquoted xend aesthetic variable.}
+\item{xend}{Unquoted \code{xend} aesthetic variable.}
 
-\item{y}{Unquoted y aesthetic variable.}
+\item{y}{Unquoted \code{y} aesthetic variable.}
 
-\item{ymin}{Unquoted ymin aesthetic variable.}
+\item{ymin}{Unquoted \code{ymin} aesthetic variable.}
 
-\item{ymax}{Unquoted ymax aesthetic variable.}
+\item{ymax}{Unquoted \code{ymax} aesthetic variable.}
 
-\item{yend}{Unquoted yend aesthetic variable.}
+\item{yend}{Unquoted \code{yend} aesthetic variable.}
 
-\item{z}{Unquoted z aesthetic variable.}
+\item{z}{Unquoted \code{z} aesthetic variable.}
 
-\item{col}{Unquoted col and fill aesthetic variable.}
+\item{col}{Unquoted \code{col} and \code{fill} aesthetic variable.}
 
-\item{alpha}{Unquoted alpha aesthetic variable.}
+\item{alpha}{Unquoted \code{alpha} aesthetic variable.}
 
-\item{facet}{Unquoted facet aesthetic variable.}
+\item{facet}{Unquoted \code{facet} aesthetic variable.}
 
 \item{facet2}{Unquoted second facet variable.}
 
-\item{group}{Unquoted group aesthetic variable.}
+\item{group}{Unquoted \code{group} aesthetic variable.}
 
-\item{subgroup}{Unquoted subgroup aesthetic variable.}
+\item{subgroup}{Unquoted \code{subgroup} aesthetic variable.}
 
-\item{label}{Unquoted label aesthetic variable.}
+\item{label}{Unquoted \code{label} aesthetic variable.}
 
-\item{text}{Unquoted text aesthetic variable.}
+\item{text}{Unquoted \code{text} aesthetic variable.}
 
-\item{sample}{Unquoted sample aesthetic variable.}
+\item{sample}{Unquoted \code{sample} aesthetic variable.}
 
-\item{mapping}{Set of additional aesthetic mappings within the ggplot2::aes function for non-supported aesthetics (e.g. shape, linetype, linewidth, or size) or for delayed evaluation.}
+\item{mapping}{Set of additional aesthetic mappings within \code{ggplot2::aes()} for non-supported aesthetics (e.g. \code{shape}, \code{linetype}, \code{linewidth}, or \code{size}) or for delayed evaluation.}
 
-\item{x_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{x_breaks, y_breaks}{A \verb{scales::breaks_*} function (e.g. \code{\link[scales:breaks_pretty]{scales::breaks_pretty()}}), or a vector of breaks.}
 
-\item{x_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{x_expand, y_expand}{Padding to the limits with the \code{ggplot2::expansion()} function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{x_expand_limits}{For a continuous x variable, any values that the limits should encompass (e.g. 0).}
+\item{x_expand_limits, y_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{x_gridlines}{TRUE or FALSE for vertical x gridlines. NULL guesses based on the classes of the x and y.}
+\item{x_gridlines}{\code{TRUE} or \code{FALSE} for vertical \code{x} gridlines. \code{NULL} guesses based on the classes of the x and y.}
 
-\item{x_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{x_labels, y_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{\link[scales:label_number]{scales::label_comma()}}), or a vector of labels.}
 
-\item{x_limits}{A vector of length 2 to determine the limits of the axis.}
+\item{x_limits, y_limits}{A vector of length 2 to determine the limits of the axis.}
 
-\item{x_oob}{For a continuous x variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{x_oob, y_oob}{For a continuous \code{x} variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
-\item{x_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
+\item{x_sec_axis, y_sec_axis}{A secondary axis using \code{ggplot2::sec_axis()} or \code{ggplot2::dup_axis()}.}
 
-\item{x_title}{Axis title string. Use "" for no title.}
+\item{x_title, y_title}{Axis title string. Use \code{""} for no title.}
 
-\item{x_transform}{For a numeric x variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{x_transform, y_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{y_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{y_gridlines}{\code{TRUE} or \code{FALSE} of horizontal \code{y} gridlines. \code{NULL} guesses based on the classes of the \code{x} and \code{y}.}
 
-\item{y_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
-
-\item{y_expand_limits}{For a continuous y variable, any values that the limits should encompass (e.g. 0).}
-
-\item{y_gridlines}{TRUE or FALSE of horizontal y gridlines. NULL guesses based on the classes of the x and y.}
-
-\item{y_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
-
-\item{y_limits}{A vector of length 2 to determine the limits of the axis.}
-
-\item{y_oob}{For a continuous y variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
-
-\item{y_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
-
-\item{y_title}{Axis title string. Use "" for no title.}
-
-\item{y_transform}{For a numeric y variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
-
-\item{col_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{col_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{col_continuous_type}{For a continuous variable, whether to colour as a "gradient" or in "steps". Defaults to "gradient".}
 
 \item{col_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{col_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{col_expand}{Padding to the limits with \code{ggplot2::expansion()}, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{col_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{col_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{col_legend_ncol}{The number of columns for the legend elements.}
+\item{col_legend_ncol, col_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{col_legend_nrow}{The number of rows for the legend elements.}
-
-\item{col_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{col_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{col_limits}{A vector to determine the limits of the scale.}
 
-\item{col_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{col_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{col_pal}{colours to use. A character vector of hex codes (or names).}
 
-\item{col_pal_na}{colour to use for NA values. A character vector of a hex code (or name).}
+\item{col_pal_na}{colour to use for \code{NA} values. A character vector of a hex code (or name).}
 
-\item{col_rescale}{For a continuous variable, a scales::rescale function.}
+\item{col_rescale}{For a continuous variable, a \code{scales::rescale} function.}
 
 \item{col_title}{Legend title string. Use "" for no title.}
 
-\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{alpha_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{alpha_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{alpha_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{alpha_legend_ncol}{The number of columns for the legend elements.}
+\item{alpha_legend_ncol, alpha_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{alpha_legend_nrow}{The number of rows for the legend elements.}
-
-\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{alpha_limits}{A vector to determine the limits of the scale.}
 
-\item{alpha_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{alpha_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{alpha_pal}{Alpha values to use as a numeric vector. For a continuous variable, a range is only needed.}
 
-\item{alpha_pal_na}{Alpha value to use for the NA value.}
+\item{alpha_pal_na}{Alpha value to use for the \code{NA} value.}
 
-\item{alpha_title}{Legend title string. Use "" for no title.}
+\item{alpha_title}{Legend title string. Use \code{""} for no title.}
 
-\item{alpha_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{alpha_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the transform_ prefix (e.g. "log10").}
 
 \item{facet_axes}{Whether to add interior axes and ticks with "margins", "all", "all_x", or "all_y".}
 
 \item{facet_axis_labels}{Whether to add interior axis labels with "margins", "all", "all_x", or "all_y".}
 
-\item{facet_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
+\item{facet_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
 
 \item{facet_labels_position}{When the facet layout is "wrap", the position of the facet labels. Either "top", "right", "bottom" or "left".}
 
 \item{facet_labels_switch}{When the facet layout is "grid", whether to switch the facet labels to the opposite side of the plot. Either "x", "y" or "both".}
 
-\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If NULL and a single facet (or facet2) argument is provided, then defaults to "wrap". If NULL and both facet and facet2 arguments are provided, defaults to "grid".}
+\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If \code{NULL} and a single \code{facet} (or \code{facet2}) argument is provided, then defaults to "wrap". If \code{NULL} and both facet and facet2 arguments are provided, defaults to "grid".}
 
 \item{facet_ncol}{The number of columns of facets. Only applies to a facet layout of "wrap".}
 
@@ -268,15 +246,15 @@ gg_hex(
 
 \item{caption}{Caption title string.}
 
-\item{titles}{A function to format unspecified titles. Defaults to snakecase::to_sentence_case.}
+\item{titles}{A function to format unspecified titles. Defaults to \code{snakecase::to_sentence_case}.}
 
-\item{flipped}{TRUE or FALSE or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
+\item{flipped}{\code{TRUE} or \code{FALSE} or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
 }
 \value{
 A ggplot object.
 }
 \description{
-Create a hex ggplot with a wrapper around ggplot() + geom_hex.
+Create a hex ggplot with a wrapper around \code{ggplot()} + \link[ggplot2:geom_hex]{geom_hex()}.
 }
 \examples{
 

--- a/man/gg_histogram.Rd
+++ b/man/gg_histogram.Rd
@@ -98,161 +98,139 @@ gg_histogram(
 \arguments{
 \item{data}{A data frame or tibble.}
 
-\item{...}{Other arguments passed to within a params list in the layer function.}
+\item{...}{Other arguments passed to within a \code{params} list in \code{layer()}.}
 
 \item{stat}{A statistical transformation to use on the data. A snakecase character string of a ggproto Stat subclass object minus the Stat prefix (e.g. "identity").}
 
-\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a position_* function that outputs a ggproto Position subclass object (e.g. ggplot2::position_identity()).}
+\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a \verb{position_*()} function that outputs a ggproto Position subclass object (e.g. \code{ggplot2::position_identity()}).}
 
-\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. ggplot2::coord_cartesian()).}
+\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. \code{\link[ggplot2:coord_cartesian]{ggplot2::coord_cartesian()}}).}
 
-\item{theme}{A ggplot2 theme (e.g. light_mode_b(), dark_mode_rt() or ggplot2::theme_grey()).}
+\item{theme}{A ggplot2 theme (e.g. \code{\link[=light_mode_b]{light_mode_b()}}, \code{\link[=dark_mode_rt]{dark_mode_rt()}} or \code{\link[ggplot2:ggtheme]{ggplot2::theme_grey()}}).}
 
-\item{x}{Unquoted x aesthetic variable.}
+\item{x}{Unquoted \code{x} aesthetic variable.}
 
-\item{xmin}{Unquoted xmin aesthetic variable.}
+\item{xmin}{Unquoted \code{xmin} aesthetic variable.}
 
-\item{xmax}{Unquoted xmax aesthetic variable.}
+\item{xmax}{Unquoted \code{xmax} aesthetic variable.}
 
-\item{xend}{Unquoted xend aesthetic variable.}
+\item{xend}{Unquoted \code{xend} aesthetic variable.}
 
-\item{y}{Unquoted y aesthetic variable.}
+\item{y}{Unquoted \code{y} aesthetic variable.}
 
-\item{ymin}{Unquoted ymin aesthetic variable.}
+\item{ymin}{Unquoted \code{ymin} aesthetic variable.}
 
-\item{ymax}{Unquoted ymax aesthetic variable.}
+\item{ymax}{Unquoted \code{ymax} aesthetic variable.}
 
-\item{yend}{Unquoted yend aesthetic variable.}
+\item{yend}{Unquoted \code{yend} aesthetic variable.}
 
-\item{z}{Unquoted z aesthetic variable.}
+\item{z}{Unquoted \code{z} aesthetic variable.}
 
-\item{col}{Unquoted col and fill aesthetic variable.}
+\item{col}{Unquoted \code{col} and \code{fill} aesthetic variable.}
 
-\item{alpha}{Unquoted alpha aesthetic variable.}
+\item{alpha}{Unquoted \code{alpha} aesthetic variable.}
 
-\item{facet}{Unquoted facet aesthetic variable.}
+\item{facet}{Unquoted \code{facet} aesthetic variable.}
 
 \item{facet2}{Unquoted second facet variable.}
 
-\item{group}{Unquoted group aesthetic variable.}
+\item{group}{Unquoted \code{group} aesthetic variable.}
 
-\item{subgroup}{Unquoted subgroup aesthetic variable.}
+\item{subgroup}{Unquoted \code{subgroup} aesthetic variable.}
 
-\item{label}{Unquoted label aesthetic variable.}
+\item{label}{Unquoted \code{label} aesthetic variable.}
 
-\item{text}{Unquoted text aesthetic variable.}
+\item{text}{Unquoted \code{text} aesthetic variable.}
 
-\item{sample}{Unquoted sample aesthetic variable.}
+\item{sample}{Unquoted \code{sample} aesthetic variable.}
 
-\item{mapping}{Set of additional aesthetic mappings within the ggplot2::aes function for non-supported aesthetics (e.g. shape, linetype, linewidth, or size) or for delayed evaluation.}
+\item{mapping}{Set of additional aesthetic mappings within \code{ggplot2::aes()} for non-supported aesthetics (e.g. \code{shape}, \code{linetype}, \code{linewidth}, or \code{size}) or for delayed evaluation.}
 
-\item{x_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{x_breaks, y_breaks}{A \verb{scales::breaks_*} function (e.g. \code{\link[scales:breaks_pretty]{scales::breaks_pretty()}}), or a vector of breaks.}
 
-\item{x_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{x_expand, y_expand}{Padding to the limits with the \code{ggplot2::expansion()} function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{x_expand_limits}{For a continuous x variable, any values that the limits should encompass (e.g. 0).}
+\item{x_expand_limits, y_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{x_gridlines}{TRUE or FALSE for vertical x gridlines. NULL guesses based on the classes of the x and y.}
+\item{x_gridlines}{\code{TRUE} or \code{FALSE} for vertical \code{x} gridlines. \code{NULL} guesses based on the classes of the x and y.}
 
-\item{x_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{x_labels, y_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{\link[scales:label_number]{scales::label_comma()}}), or a vector of labels.}
 
-\item{x_limits}{A vector of length 2 to determine the limits of the axis.}
+\item{x_limits, y_limits}{A vector of length 2 to determine the limits of the axis.}
 
-\item{x_oob}{For a continuous x variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{x_oob, y_oob}{For a continuous \code{x} variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
-\item{x_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
+\item{x_sec_axis, y_sec_axis}{A secondary axis using \code{ggplot2::sec_axis()} or \code{ggplot2::dup_axis()}.}
 
-\item{x_title}{Axis title string. Use "" for no title.}
+\item{x_title, y_title}{Axis title string. Use \code{""} for no title.}
 
-\item{x_transform}{For a numeric x variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{x_transform, y_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{y_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{y_gridlines}{\code{TRUE} or \code{FALSE} of horizontal \code{y} gridlines. \code{NULL} guesses based on the classes of the \code{x} and \code{y}.}
 
-\item{y_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
-
-\item{y_expand_limits}{For a continuous y variable, any values that the limits should encompass (e.g. 0).}
-
-\item{y_gridlines}{TRUE or FALSE of horizontal y gridlines. NULL guesses based on the classes of the x and y.}
-
-\item{y_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
-
-\item{y_limits}{A vector of length 2 to determine the limits of the axis.}
-
-\item{y_oob}{For a continuous y variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
-
-\item{y_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
-
-\item{y_title}{Axis title string. Use "" for no title.}
-
-\item{y_transform}{For a numeric y variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
-
-\item{col_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{col_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{col_continuous_type}{For a continuous variable, whether to colour as a "gradient" or in "steps". Defaults to "gradient".}
 
 \item{col_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{col_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{col_expand}{Padding to the limits with \code{ggplot2::expansion()}, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{col_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{col_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{col_legend_ncol}{The number of columns for the legend elements.}
+\item{col_legend_ncol, col_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{col_legend_nrow}{The number of rows for the legend elements.}
-
-\item{col_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{col_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{col_limits}{A vector to determine the limits of the scale.}
 
-\item{col_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{col_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{col_pal}{colours to use. A character vector of hex codes (or names).}
 
-\item{col_pal_na}{colour to use for NA values. A character vector of a hex code (or name).}
+\item{col_pal_na}{colour to use for \code{NA} values. A character vector of a hex code (or name).}
 
-\item{col_rescale}{For a continuous variable, a scales::rescale function.}
+\item{col_rescale}{For a continuous variable, a \code{scales::rescale} function.}
 
 \item{col_title}{Legend title string. Use "" for no title.}
 
-\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{alpha_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{alpha_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{alpha_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{alpha_legend_ncol}{The number of columns for the legend elements.}
+\item{alpha_legend_ncol, alpha_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{alpha_legend_nrow}{The number of rows for the legend elements.}
-
-\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{alpha_limits}{A vector to determine the limits of the scale.}
 
-\item{alpha_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{alpha_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{alpha_pal}{Alpha values to use as a numeric vector. For a continuous variable, a range is only needed.}
 
-\item{alpha_pal_na}{Alpha value to use for the NA value.}
+\item{alpha_pal_na}{Alpha value to use for the \code{NA} value.}
 
-\item{alpha_title}{Legend title string. Use "" for no title.}
+\item{alpha_title}{Legend title string. Use \code{""} for no title.}
 
-\item{alpha_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{alpha_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the transform_ prefix (e.g. "log10").}
 
 \item{facet_axes}{Whether to add interior axes and ticks with "margins", "all", "all_x", or "all_y".}
 
 \item{facet_axis_labels}{Whether to add interior axis labels with "margins", "all", "all_x", or "all_y".}
 
-\item{facet_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
+\item{facet_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
 
 \item{facet_labels_position}{When the facet layout is "wrap", the position of the facet labels. Either "top", "right", "bottom" or "left".}
 
 \item{facet_labels_switch}{When the facet layout is "grid", whether to switch the facet labels to the opposite side of the plot. Either "x", "y" or "both".}
 
-\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If NULL and a single facet (or facet2) argument is provided, then defaults to "wrap". If NULL and both facet and facet2 arguments are provided, defaults to "grid".}
+\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If \code{NULL} and a single \code{facet} (or \code{facet2}) argument is provided, then defaults to "wrap". If \code{NULL} and both facet and facet2 arguments are provided, defaults to "grid".}
 
 \item{facet_ncol}{The number of columns of facets. Only applies to a facet layout of "wrap".}
 
@@ -268,15 +246,15 @@ gg_histogram(
 
 \item{caption}{Caption title string.}
 
-\item{titles}{A function to format unspecified titles. Defaults to snakecase::to_sentence_case.}
+\item{titles}{A function to format unspecified titles. Defaults to \code{snakecase::to_sentence_case}.}
 
-\item{flipped}{TRUE or FALSE or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
+\item{flipped}{\code{TRUE} or \code{FALSE} or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
 }
 \value{
 A ggplot object.
 }
 \description{
-Create a histogram ggplot with a wrapper around ggplot() + geom_histogram.
+Create a histogram ggplot with a wrapper around \code{ggplot()} + \link[ggplot2:geom_histogram]{geom_histogram()}.
 }
 \examples{
 

--- a/man/gg_jitter.Rd
+++ b/man/gg_jitter.Rd
@@ -98,161 +98,139 @@ gg_jitter(
 \arguments{
 \item{data}{A data frame or tibble.}
 
-\item{...}{Other arguments passed to within a params list in the layer function.}
+\item{...}{Other arguments passed to within a \code{params} list in \code{layer()}.}
 
 \item{stat}{A statistical transformation to use on the data. A snakecase character string of a ggproto Stat subclass object minus the Stat prefix (e.g. "identity").}
 
-\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a position_* function that outputs a ggproto Position subclass object (e.g. ggplot2::position_identity()).}
+\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a \verb{position_*()} function that outputs a ggproto Position subclass object (e.g. \code{ggplot2::position_identity()}).}
 
-\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. ggplot2::coord_cartesian()).}
+\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. \code{\link[ggplot2:coord_cartesian]{ggplot2::coord_cartesian()}}).}
 
-\item{theme}{A ggplot2 theme (e.g. light_mode_b(), dark_mode_rt() or ggplot2::theme_grey()).}
+\item{theme}{A ggplot2 theme (e.g. \code{\link[=light_mode_b]{light_mode_b()}}, \code{\link[=dark_mode_rt]{dark_mode_rt()}} or \code{\link[ggplot2:ggtheme]{ggplot2::theme_grey()}}).}
 
-\item{x}{Unquoted x aesthetic variable.}
+\item{x}{Unquoted \code{x} aesthetic variable.}
 
-\item{xmin}{Unquoted xmin aesthetic variable.}
+\item{xmin}{Unquoted \code{xmin} aesthetic variable.}
 
-\item{xmax}{Unquoted xmax aesthetic variable.}
+\item{xmax}{Unquoted \code{xmax} aesthetic variable.}
 
-\item{xend}{Unquoted xend aesthetic variable.}
+\item{xend}{Unquoted \code{xend} aesthetic variable.}
 
-\item{y}{Unquoted y aesthetic variable.}
+\item{y}{Unquoted \code{y} aesthetic variable.}
 
-\item{ymin}{Unquoted ymin aesthetic variable.}
+\item{ymin}{Unquoted \code{ymin} aesthetic variable.}
 
-\item{ymax}{Unquoted ymax aesthetic variable.}
+\item{ymax}{Unquoted \code{ymax} aesthetic variable.}
 
-\item{yend}{Unquoted yend aesthetic variable.}
+\item{yend}{Unquoted \code{yend} aesthetic variable.}
 
-\item{z}{Unquoted z aesthetic variable.}
+\item{z}{Unquoted \code{z} aesthetic variable.}
 
-\item{col}{Unquoted col and fill aesthetic variable.}
+\item{col}{Unquoted \code{col} and \code{fill} aesthetic variable.}
 
-\item{alpha}{Unquoted alpha aesthetic variable.}
+\item{alpha}{Unquoted \code{alpha} aesthetic variable.}
 
-\item{facet}{Unquoted facet aesthetic variable.}
+\item{facet}{Unquoted \code{facet} aesthetic variable.}
 
 \item{facet2}{Unquoted second facet variable.}
 
-\item{group}{Unquoted group aesthetic variable.}
+\item{group}{Unquoted \code{group} aesthetic variable.}
 
-\item{subgroup}{Unquoted subgroup aesthetic variable.}
+\item{subgroup}{Unquoted \code{subgroup} aesthetic variable.}
 
-\item{label}{Unquoted label aesthetic variable.}
+\item{label}{Unquoted \code{label} aesthetic variable.}
 
-\item{text}{Unquoted text aesthetic variable.}
+\item{text}{Unquoted \code{text} aesthetic variable.}
 
-\item{sample}{Unquoted sample aesthetic variable.}
+\item{sample}{Unquoted \code{sample} aesthetic variable.}
 
-\item{mapping}{Set of additional aesthetic mappings within the ggplot2::aes function for non-supported aesthetics (e.g. shape, linetype, linewidth, or size) or for delayed evaluation.}
+\item{mapping}{Set of additional aesthetic mappings within \code{ggplot2::aes()} for non-supported aesthetics (e.g. \code{shape}, \code{linetype}, \code{linewidth}, or \code{size}) or for delayed evaluation.}
 
-\item{x_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{x_breaks, y_breaks}{A \verb{scales::breaks_*} function (e.g. \code{\link[scales:breaks_pretty]{scales::breaks_pretty()}}), or a vector of breaks.}
 
-\item{x_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{x_expand, y_expand}{Padding to the limits with the \code{ggplot2::expansion()} function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{x_expand_limits}{For a continuous x variable, any values that the limits should encompass (e.g. 0).}
+\item{x_expand_limits, y_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{x_gridlines}{TRUE or FALSE for vertical x gridlines. NULL guesses based on the classes of the x and y.}
+\item{x_gridlines}{\code{TRUE} or \code{FALSE} for vertical \code{x} gridlines. \code{NULL} guesses based on the classes of the x and y.}
 
-\item{x_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{x_labels, y_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{\link[scales:label_number]{scales::label_comma()}}), or a vector of labels.}
 
-\item{x_limits}{A vector of length 2 to determine the limits of the axis.}
+\item{x_limits, y_limits}{A vector of length 2 to determine the limits of the axis.}
 
-\item{x_oob}{For a continuous x variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{x_oob, y_oob}{For a continuous \code{x} variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
-\item{x_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
+\item{x_sec_axis, y_sec_axis}{A secondary axis using \code{ggplot2::sec_axis()} or \code{ggplot2::dup_axis()}.}
 
-\item{x_title}{Axis title string. Use "" for no title.}
+\item{x_title, y_title}{Axis title string. Use \code{""} for no title.}
 
-\item{x_transform}{For a numeric x variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{x_transform, y_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{y_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{y_gridlines}{\code{TRUE} or \code{FALSE} of horizontal \code{y} gridlines. \code{NULL} guesses based on the classes of the \code{x} and \code{y}.}
 
-\item{y_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
-
-\item{y_expand_limits}{For a continuous y variable, any values that the limits should encompass (e.g. 0).}
-
-\item{y_gridlines}{TRUE or FALSE of horizontal y gridlines. NULL guesses based on the classes of the x and y.}
-
-\item{y_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
-
-\item{y_limits}{A vector of length 2 to determine the limits of the axis.}
-
-\item{y_oob}{For a continuous y variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
-
-\item{y_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
-
-\item{y_title}{Axis title string. Use "" for no title.}
-
-\item{y_transform}{For a numeric y variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
-
-\item{col_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{col_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{col_continuous_type}{For a continuous variable, whether to colour as a "gradient" or in "steps". Defaults to "gradient".}
 
 \item{col_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{col_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{col_expand}{Padding to the limits with \code{ggplot2::expansion()}, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{col_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{col_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{col_legend_ncol}{The number of columns for the legend elements.}
+\item{col_legend_ncol, col_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{col_legend_nrow}{The number of rows for the legend elements.}
-
-\item{col_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{col_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{col_limits}{A vector to determine the limits of the scale.}
 
-\item{col_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{col_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{col_pal}{colours to use. A character vector of hex codes (or names).}
 
-\item{col_pal_na}{colour to use for NA values. A character vector of a hex code (or name).}
+\item{col_pal_na}{colour to use for \code{NA} values. A character vector of a hex code (or name).}
 
-\item{col_rescale}{For a continuous variable, a scales::rescale function.}
+\item{col_rescale}{For a continuous variable, a \code{scales::rescale} function.}
 
 \item{col_title}{Legend title string. Use "" for no title.}
 
-\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{alpha_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{alpha_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{alpha_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{alpha_legend_ncol}{The number of columns for the legend elements.}
+\item{alpha_legend_ncol, alpha_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{alpha_legend_nrow}{The number of rows for the legend elements.}
-
-\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{alpha_limits}{A vector to determine the limits of the scale.}
 
-\item{alpha_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{alpha_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{alpha_pal}{Alpha values to use as a numeric vector. For a continuous variable, a range is only needed.}
 
-\item{alpha_pal_na}{Alpha value to use for the NA value.}
+\item{alpha_pal_na}{Alpha value to use for the \code{NA} value.}
 
-\item{alpha_title}{Legend title string. Use "" for no title.}
+\item{alpha_title}{Legend title string. Use \code{""} for no title.}
 
-\item{alpha_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{alpha_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the transform_ prefix (e.g. "log10").}
 
 \item{facet_axes}{Whether to add interior axes and ticks with "margins", "all", "all_x", or "all_y".}
 
 \item{facet_axis_labels}{Whether to add interior axis labels with "margins", "all", "all_x", or "all_y".}
 
-\item{facet_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
+\item{facet_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
 
 \item{facet_labels_position}{When the facet layout is "wrap", the position of the facet labels. Either "top", "right", "bottom" or "left".}
 
 \item{facet_labels_switch}{When the facet layout is "grid", whether to switch the facet labels to the opposite side of the plot. Either "x", "y" or "both".}
 
-\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If NULL and a single facet (or facet2) argument is provided, then defaults to "wrap". If NULL and both facet and facet2 arguments are provided, defaults to "grid".}
+\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If \code{NULL} and a single \code{facet} (or \code{facet2}) argument is provided, then defaults to "wrap". If \code{NULL} and both facet and facet2 arguments are provided, defaults to "grid".}
 
 \item{facet_ncol}{The number of columns of facets. Only applies to a facet layout of "wrap".}
 
@@ -268,15 +246,15 @@ gg_jitter(
 
 \item{caption}{Caption title string.}
 
-\item{titles}{A function to format unspecified titles. Defaults to snakecase::to_sentence_case.}
+\item{titles}{A function to format unspecified titles. Defaults to \code{snakecase::to_sentence_case}.}
 
-\item{flipped}{TRUE or FALSE or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
+\item{flipped}{\code{TRUE} or \code{FALSE} or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
 }
 \value{
 A ggplot object.
 }
 \description{
-Create a jitter ggplot with a wrapper around ggplot() + geom_jitter.
+Create a jitter ggplot with a wrapper around \code{ggplot()} + \link[ggplot2:geom_jitter]{geom_jitter()}.
 }
 \examples{
 

--- a/man/gg_label.Rd
+++ b/man/gg_label.Rd
@@ -98,161 +98,139 @@ gg_label(
 \arguments{
 \item{data}{A data frame or tibble.}
 
-\item{...}{Other arguments passed to within a params list in the layer function.}
+\item{...}{Other arguments passed to within a \code{params} list in \code{layer()}.}
 
 \item{stat}{A statistical transformation to use on the data. A snakecase character string of a ggproto Stat subclass object minus the Stat prefix (e.g. "identity").}
 
-\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a position_* function that outputs a ggproto Position subclass object (e.g. ggplot2::position_identity()).}
+\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a \verb{position_*()} function that outputs a ggproto Position subclass object (e.g. \code{ggplot2::position_identity()}).}
 
-\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. ggplot2::coord_cartesian()).}
+\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. \code{\link[ggplot2:coord_cartesian]{ggplot2::coord_cartesian()}}).}
 
-\item{theme}{A ggplot2 theme (e.g. light_mode_b(), dark_mode_rt() or ggplot2::theme_grey()).}
+\item{theme}{A ggplot2 theme (e.g. \code{\link[=light_mode_b]{light_mode_b()}}, \code{\link[=dark_mode_rt]{dark_mode_rt()}} or \code{\link[ggplot2:ggtheme]{ggplot2::theme_grey()}}).}
 
-\item{x}{Unquoted x aesthetic variable.}
+\item{x}{Unquoted \code{x} aesthetic variable.}
 
-\item{xmin}{Unquoted xmin aesthetic variable.}
+\item{xmin}{Unquoted \code{xmin} aesthetic variable.}
 
-\item{xmax}{Unquoted xmax aesthetic variable.}
+\item{xmax}{Unquoted \code{xmax} aesthetic variable.}
 
-\item{xend}{Unquoted xend aesthetic variable.}
+\item{xend}{Unquoted \code{xend} aesthetic variable.}
 
-\item{y}{Unquoted y aesthetic variable.}
+\item{y}{Unquoted \code{y} aesthetic variable.}
 
-\item{ymin}{Unquoted ymin aesthetic variable.}
+\item{ymin}{Unquoted \code{ymin} aesthetic variable.}
 
-\item{ymax}{Unquoted ymax aesthetic variable.}
+\item{ymax}{Unquoted \code{ymax} aesthetic variable.}
 
-\item{yend}{Unquoted yend aesthetic variable.}
+\item{yend}{Unquoted \code{yend} aesthetic variable.}
 
-\item{z}{Unquoted z aesthetic variable.}
+\item{z}{Unquoted \code{z} aesthetic variable.}
 
-\item{col}{Unquoted col and fill aesthetic variable.}
+\item{col}{Unquoted \code{col} and \code{fill} aesthetic variable.}
 
-\item{alpha}{Unquoted alpha aesthetic variable.}
+\item{alpha}{Unquoted \code{alpha} aesthetic variable.}
 
-\item{facet}{Unquoted facet aesthetic variable.}
+\item{facet}{Unquoted \code{facet} aesthetic variable.}
 
 \item{facet2}{Unquoted second facet variable.}
 
-\item{group}{Unquoted group aesthetic variable.}
+\item{group}{Unquoted \code{group} aesthetic variable.}
 
-\item{subgroup}{Unquoted subgroup aesthetic variable.}
+\item{subgroup}{Unquoted \code{subgroup} aesthetic variable.}
 
-\item{label}{Unquoted label aesthetic variable.}
+\item{label}{Unquoted \code{label} aesthetic variable.}
 
-\item{text}{Unquoted text aesthetic variable.}
+\item{text}{Unquoted \code{text} aesthetic variable.}
 
-\item{sample}{Unquoted sample aesthetic variable.}
+\item{sample}{Unquoted \code{sample} aesthetic variable.}
 
-\item{mapping}{Set of additional aesthetic mappings within the ggplot2::aes function for non-supported aesthetics (e.g. shape, linetype, linewidth, or size) or for delayed evaluation.}
+\item{mapping}{Set of additional aesthetic mappings within \code{ggplot2::aes()} for non-supported aesthetics (e.g. \code{shape}, \code{linetype}, \code{linewidth}, or \code{size}) or for delayed evaluation.}
 
-\item{x_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{x_breaks, y_breaks}{A \verb{scales::breaks_*} function (e.g. \code{\link[scales:breaks_pretty]{scales::breaks_pretty()}}), or a vector of breaks.}
 
-\item{x_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{x_expand, y_expand}{Padding to the limits with the \code{ggplot2::expansion()} function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{x_expand_limits}{For a continuous x variable, any values that the limits should encompass (e.g. 0).}
+\item{x_expand_limits, y_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{x_gridlines}{TRUE or FALSE for vertical x gridlines. NULL guesses based on the classes of the x and y.}
+\item{x_gridlines}{\code{TRUE} or \code{FALSE} for vertical \code{x} gridlines. \code{NULL} guesses based on the classes of the x and y.}
 
-\item{x_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{x_labels, y_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{\link[scales:label_number]{scales::label_comma()}}), or a vector of labels.}
 
-\item{x_limits}{A vector of length 2 to determine the limits of the axis.}
+\item{x_limits, y_limits}{A vector of length 2 to determine the limits of the axis.}
 
-\item{x_oob}{For a continuous x variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{x_oob, y_oob}{For a continuous \code{x} variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
-\item{x_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
+\item{x_sec_axis, y_sec_axis}{A secondary axis using \code{ggplot2::sec_axis()} or \code{ggplot2::dup_axis()}.}
 
-\item{x_title}{Axis title string. Use "" for no title.}
+\item{x_title, y_title}{Axis title string. Use \code{""} for no title.}
 
-\item{x_transform}{For a numeric x variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{x_transform, y_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{y_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{y_gridlines}{\code{TRUE} or \code{FALSE} of horizontal \code{y} gridlines. \code{NULL} guesses based on the classes of the \code{x} and \code{y}.}
 
-\item{y_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
-
-\item{y_expand_limits}{For a continuous y variable, any values that the limits should encompass (e.g. 0).}
-
-\item{y_gridlines}{TRUE or FALSE of horizontal y gridlines. NULL guesses based on the classes of the x and y.}
-
-\item{y_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
-
-\item{y_limits}{A vector of length 2 to determine the limits of the axis.}
-
-\item{y_oob}{For a continuous y variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
-
-\item{y_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
-
-\item{y_title}{Axis title string. Use "" for no title.}
-
-\item{y_transform}{For a numeric y variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
-
-\item{col_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{col_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{col_continuous_type}{For a continuous variable, whether to colour as a "gradient" or in "steps". Defaults to "gradient".}
 
 \item{col_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{col_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{col_expand}{Padding to the limits with \code{ggplot2::expansion()}, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{col_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{col_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{col_legend_ncol}{The number of columns for the legend elements.}
+\item{col_legend_ncol, col_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{col_legend_nrow}{The number of rows for the legend elements.}
-
-\item{col_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{col_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{col_limits}{A vector to determine the limits of the scale.}
 
-\item{col_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{col_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{col_pal}{colours to use. A character vector of hex codes (or names).}
 
-\item{col_pal_na}{colour to use for NA values. A character vector of a hex code (or name).}
+\item{col_pal_na}{colour to use for \code{NA} values. A character vector of a hex code (or name).}
 
-\item{col_rescale}{For a continuous variable, a scales::rescale function.}
+\item{col_rescale}{For a continuous variable, a \code{scales::rescale} function.}
 
 \item{col_title}{Legend title string. Use "" for no title.}
 
-\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{alpha_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{alpha_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{alpha_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{alpha_legend_ncol}{The number of columns for the legend elements.}
+\item{alpha_legend_ncol, alpha_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{alpha_legend_nrow}{The number of rows for the legend elements.}
-
-\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{alpha_limits}{A vector to determine the limits of the scale.}
 
-\item{alpha_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{alpha_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{alpha_pal}{Alpha values to use as a numeric vector. For a continuous variable, a range is only needed.}
 
-\item{alpha_pal_na}{Alpha value to use for the NA value.}
+\item{alpha_pal_na}{Alpha value to use for the \code{NA} value.}
 
-\item{alpha_title}{Legend title string. Use "" for no title.}
+\item{alpha_title}{Legend title string. Use \code{""} for no title.}
 
-\item{alpha_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{alpha_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the transform_ prefix (e.g. "log10").}
 
 \item{facet_axes}{Whether to add interior axes and ticks with "margins", "all", "all_x", or "all_y".}
 
 \item{facet_axis_labels}{Whether to add interior axis labels with "margins", "all", "all_x", or "all_y".}
 
-\item{facet_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
+\item{facet_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
 
 \item{facet_labels_position}{When the facet layout is "wrap", the position of the facet labels. Either "top", "right", "bottom" or "left".}
 
 \item{facet_labels_switch}{When the facet layout is "grid", whether to switch the facet labels to the opposite side of the plot. Either "x", "y" or "both".}
 
-\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If NULL and a single facet (or facet2) argument is provided, then defaults to "wrap". If NULL and both facet and facet2 arguments are provided, defaults to "grid".}
+\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If \code{NULL} and a single \code{facet} (or \code{facet2}) argument is provided, then defaults to "wrap". If \code{NULL} and both facet and facet2 arguments are provided, defaults to "grid".}
 
 \item{facet_ncol}{The number of columns of facets. Only applies to a facet layout of "wrap".}
 
@@ -268,15 +246,15 @@ gg_label(
 
 \item{caption}{Caption title string.}
 
-\item{titles}{A function to format unspecified titles. Defaults to snakecase::to_sentence_case.}
+\item{titles}{A function to format unspecified titles. Defaults to \code{snakecase::to_sentence_case}.}
 
-\item{flipped}{TRUE or FALSE or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
+\item{flipped}{\code{TRUE} or \code{FALSE} or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
 }
 \value{
 A ggplot object.
 }
 \description{
-Create a label ggplot with a wrapper around ggplot() + geom_label.
+Create a label ggplot with a wrapper around \code{ggplot()} + \link[ggplot2:geom_text]{geom_label()}.
 }
 \examples{
 

--- a/man/gg_line.Rd
+++ b/man/gg_line.Rd
@@ -98,161 +98,139 @@ gg_line(
 \arguments{
 \item{data}{A data frame or tibble.}
 
-\item{...}{Other arguments passed to within a params list in the layer function.}
+\item{...}{Other arguments passed to within a \code{params} list in \code{layer()}.}
 
 \item{stat}{A statistical transformation to use on the data. A snakecase character string of a ggproto Stat subclass object minus the Stat prefix (e.g. "identity").}
 
-\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a position_* function that outputs a ggproto Position subclass object (e.g. ggplot2::position_identity()).}
+\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a \verb{position_*()} function that outputs a ggproto Position subclass object (e.g. \code{ggplot2::position_identity()}).}
 
-\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. ggplot2::coord_cartesian()).}
+\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. \code{\link[ggplot2:coord_cartesian]{ggplot2::coord_cartesian()}}).}
 
-\item{theme}{A ggplot2 theme (e.g. light_mode_b(), dark_mode_rt() or ggplot2::theme_grey()).}
+\item{theme}{A ggplot2 theme (e.g. \code{\link[=light_mode_b]{light_mode_b()}}, \code{\link[=dark_mode_rt]{dark_mode_rt()}} or \code{\link[ggplot2:ggtheme]{ggplot2::theme_grey()}}).}
 
-\item{x}{Unquoted x aesthetic variable.}
+\item{x}{Unquoted \code{x} aesthetic variable.}
 
-\item{xmin}{Unquoted xmin aesthetic variable.}
+\item{xmin}{Unquoted \code{xmin} aesthetic variable.}
 
-\item{xmax}{Unquoted xmax aesthetic variable.}
+\item{xmax}{Unquoted \code{xmax} aesthetic variable.}
 
-\item{xend}{Unquoted xend aesthetic variable.}
+\item{xend}{Unquoted \code{xend} aesthetic variable.}
 
-\item{y}{Unquoted y aesthetic variable.}
+\item{y}{Unquoted \code{y} aesthetic variable.}
 
-\item{ymin}{Unquoted ymin aesthetic variable.}
+\item{ymin}{Unquoted \code{ymin} aesthetic variable.}
 
-\item{ymax}{Unquoted ymax aesthetic variable.}
+\item{ymax}{Unquoted \code{ymax} aesthetic variable.}
 
-\item{yend}{Unquoted yend aesthetic variable.}
+\item{yend}{Unquoted \code{yend} aesthetic variable.}
 
-\item{z}{Unquoted z aesthetic variable.}
+\item{z}{Unquoted \code{z} aesthetic variable.}
 
-\item{col}{Unquoted col and fill aesthetic variable.}
+\item{col}{Unquoted \code{col} and \code{fill} aesthetic variable.}
 
-\item{alpha}{Unquoted alpha aesthetic variable.}
+\item{alpha}{Unquoted \code{alpha} aesthetic variable.}
 
-\item{facet}{Unquoted facet aesthetic variable.}
+\item{facet}{Unquoted \code{facet} aesthetic variable.}
 
 \item{facet2}{Unquoted second facet variable.}
 
-\item{group}{Unquoted group aesthetic variable.}
+\item{group}{Unquoted \code{group} aesthetic variable.}
 
-\item{subgroup}{Unquoted subgroup aesthetic variable.}
+\item{subgroup}{Unquoted \code{subgroup} aesthetic variable.}
 
-\item{label}{Unquoted label aesthetic variable.}
+\item{label}{Unquoted \code{label} aesthetic variable.}
 
-\item{text}{Unquoted text aesthetic variable.}
+\item{text}{Unquoted \code{text} aesthetic variable.}
 
-\item{sample}{Unquoted sample aesthetic variable.}
+\item{sample}{Unquoted \code{sample} aesthetic variable.}
 
-\item{mapping}{Set of additional aesthetic mappings within the ggplot2::aes function for non-supported aesthetics (e.g. shape, linetype, linewidth, or size) or for delayed evaluation.}
+\item{mapping}{Set of additional aesthetic mappings within \code{ggplot2::aes()} for non-supported aesthetics (e.g. \code{shape}, \code{linetype}, \code{linewidth}, or \code{size}) or for delayed evaluation.}
 
-\item{x_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{x_breaks, y_breaks}{A \verb{scales::breaks_*} function (e.g. \code{\link[scales:breaks_pretty]{scales::breaks_pretty()}}), or a vector of breaks.}
 
-\item{x_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{x_expand, y_expand}{Padding to the limits with the \code{ggplot2::expansion()} function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{x_expand_limits}{For a continuous x variable, any values that the limits should encompass (e.g. 0).}
+\item{x_expand_limits, y_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{x_gridlines}{TRUE or FALSE for vertical x gridlines. NULL guesses based on the classes of the x and y.}
+\item{x_gridlines}{\code{TRUE} or \code{FALSE} for vertical \code{x} gridlines. \code{NULL} guesses based on the classes of the x and y.}
 
-\item{x_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{x_labels, y_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{\link[scales:label_number]{scales::label_comma()}}), or a vector of labels.}
 
-\item{x_limits}{A vector of length 2 to determine the limits of the axis.}
+\item{x_limits, y_limits}{A vector of length 2 to determine the limits of the axis.}
 
-\item{x_oob}{For a continuous x variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{x_oob, y_oob}{For a continuous \code{x} variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
-\item{x_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
+\item{x_sec_axis, y_sec_axis}{A secondary axis using \code{ggplot2::sec_axis()} or \code{ggplot2::dup_axis()}.}
 
-\item{x_title}{Axis title string. Use "" for no title.}
+\item{x_title, y_title}{Axis title string. Use \code{""} for no title.}
 
-\item{x_transform}{For a numeric x variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{x_transform, y_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{y_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{y_gridlines}{\code{TRUE} or \code{FALSE} of horizontal \code{y} gridlines. \code{NULL} guesses based on the classes of the \code{x} and \code{y}.}
 
-\item{y_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
-
-\item{y_expand_limits}{For a continuous y variable, any values that the limits should encompass (e.g. 0).}
-
-\item{y_gridlines}{TRUE or FALSE of horizontal y gridlines. NULL guesses based on the classes of the x and y.}
-
-\item{y_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
-
-\item{y_limits}{A vector of length 2 to determine the limits of the axis.}
-
-\item{y_oob}{For a continuous y variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
-
-\item{y_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
-
-\item{y_title}{Axis title string. Use "" for no title.}
-
-\item{y_transform}{For a numeric y variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
-
-\item{col_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{col_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{col_continuous_type}{For a continuous variable, whether to colour as a "gradient" or in "steps". Defaults to "gradient".}
 
 \item{col_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{col_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{col_expand}{Padding to the limits with \code{ggplot2::expansion()}, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{col_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{col_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{col_legend_ncol}{The number of columns for the legend elements.}
+\item{col_legend_ncol, col_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{col_legend_nrow}{The number of rows for the legend elements.}
-
-\item{col_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{col_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{col_limits}{A vector to determine the limits of the scale.}
 
-\item{col_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{col_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{col_pal}{colours to use. A character vector of hex codes (or names).}
 
-\item{col_pal_na}{colour to use for NA values. A character vector of a hex code (or name).}
+\item{col_pal_na}{colour to use for \code{NA} values. A character vector of a hex code (or name).}
 
-\item{col_rescale}{For a continuous variable, a scales::rescale function.}
+\item{col_rescale}{For a continuous variable, a \code{scales::rescale} function.}
 
 \item{col_title}{Legend title string. Use "" for no title.}
 
-\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{alpha_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{alpha_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{alpha_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{alpha_legend_ncol}{The number of columns for the legend elements.}
+\item{alpha_legend_ncol, alpha_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{alpha_legend_nrow}{The number of rows for the legend elements.}
-
-\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{alpha_limits}{A vector to determine the limits of the scale.}
 
-\item{alpha_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{alpha_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{alpha_pal}{Alpha values to use as a numeric vector. For a continuous variable, a range is only needed.}
 
-\item{alpha_pal_na}{Alpha value to use for the NA value.}
+\item{alpha_pal_na}{Alpha value to use for the \code{NA} value.}
 
-\item{alpha_title}{Legend title string. Use "" for no title.}
+\item{alpha_title}{Legend title string. Use \code{""} for no title.}
 
-\item{alpha_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{alpha_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the transform_ prefix (e.g. "log10").}
 
 \item{facet_axes}{Whether to add interior axes and ticks with "margins", "all", "all_x", or "all_y".}
 
 \item{facet_axis_labels}{Whether to add interior axis labels with "margins", "all", "all_x", or "all_y".}
 
-\item{facet_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
+\item{facet_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
 
 \item{facet_labels_position}{When the facet layout is "wrap", the position of the facet labels. Either "top", "right", "bottom" or "left".}
 
 \item{facet_labels_switch}{When the facet layout is "grid", whether to switch the facet labels to the opposite side of the plot. Either "x", "y" or "both".}
 
-\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If NULL and a single facet (or facet2) argument is provided, then defaults to "wrap". If NULL and both facet and facet2 arguments are provided, defaults to "grid".}
+\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If \code{NULL} and a single \code{facet} (or \code{facet2}) argument is provided, then defaults to "wrap". If \code{NULL} and both facet and facet2 arguments are provided, defaults to "grid".}
 
 \item{facet_ncol}{The number of columns of facets. Only applies to a facet layout of "wrap".}
 
@@ -268,15 +246,15 @@ gg_line(
 
 \item{caption}{Caption title string.}
 
-\item{titles}{A function to format unspecified titles. Defaults to snakecase::to_sentence_case.}
+\item{titles}{A function to format unspecified titles. Defaults to \code{snakecase::to_sentence_case}.}
 
-\item{flipped}{TRUE or FALSE or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
+\item{flipped}{\code{TRUE} or \code{FALSE} or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
 }
 \value{
 A ggplot object.
 }
 \description{
-Create a line ggplot with a wrapper around ggplot() + geom_line.
+Create a line ggplot with a wrapper around \code{ggplot()} + \link[ggplot2:geom_path]{geom_line()}.
 }
 \examples{
 

--- a/man/gg_linerange.Rd
+++ b/man/gg_linerange.Rd
@@ -98,161 +98,139 @@ gg_linerange(
 \arguments{
 \item{data}{A data frame or tibble.}
 
-\item{...}{Other arguments passed to within a params list in the layer function.}
+\item{...}{Other arguments passed to within a \code{params} list in \code{layer()}.}
 
 \item{stat}{A statistical transformation to use on the data. A snakecase character string of a ggproto Stat subclass object minus the Stat prefix (e.g. "identity").}
 
-\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a position_* function that outputs a ggproto Position subclass object (e.g. ggplot2::position_identity()).}
+\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a \verb{position_*()} function that outputs a ggproto Position subclass object (e.g. \code{ggplot2::position_identity()}).}
 
-\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. ggplot2::coord_cartesian()).}
+\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. \code{\link[ggplot2:coord_cartesian]{ggplot2::coord_cartesian()}}).}
 
-\item{theme}{A ggplot2 theme (e.g. light_mode_b(), dark_mode_rt() or ggplot2::theme_grey()).}
+\item{theme}{A ggplot2 theme (e.g. \code{\link[=light_mode_b]{light_mode_b()}}, \code{\link[=dark_mode_rt]{dark_mode_rt()}} or \code{\link[ggplot2:ggtheme]{ggplot2::theme_grey()}}).}
 
-\item{x}{Unquoted x aesthetic variable.}
+\item{x}{Unquoted \code{x} aesthetic variable.}
 
-\item{xmin}{Unquoted xmin aesthetic variable.}
+\item{xmin}{Unquoted \code{xmin} aesthetic variable.}
 
-\item{xmax}{Unquoted xmax aesthetic variable.}
+\item{xmax}{Unquoted \code{xmax} aesthetic variable.}
 
-\item{xend}{Unquoted xend aesthetic variable.}
+\item{xend}{Unquoted \code{xend} aesthetic variable.}
 
-\item{y}{Unquoted y aesthetic variable.}
+\item{y}{Unquoted \code{y} aesthetic variable.}
 
-\item{ymin}{Unquoted ymin aesthetic variable.}
+\item{ymin}{Unquoted \code{ymin} aesthetic variable.}
 
-\item{ymax}{Unquoted ymax aesthetic variable.}
+\item{ymax}{Unquoted \code{ymax} aesthetic variable.}
 
-\item{yend}{Unquoted yend aesthetic variable.}
+\item{yend}{Unquoted \code{yend} aesthetic variable.}
 
-\item{z}{Unquoted z aesthetic variable.}
+\item{z}{Unquoted \code{z} aesthetic variable.}
 
-\item{col}{Unquoted col and fill aesthetic variable.}
+\item{col}{Unquoted \code{col} and \code{fill} aesthetic variable.}
 
-\item{alpha}{Unquoted alpha aesthetic variable.}
+\item{alpha}{Unquoted \code{alpha} aesthetic variable.}
 
-\item{facet}{Unquoted facet aesthetic variable.}
+\item{facet}{Unquoted \code{facet} aesthetic variable.}
 
 \item{facet2}{Unquoted second facet variable.}
 
-\item{group}{Unquoted group aesthetic variable.}
+\item{group}{Unquoted \code{group} aesthetic variable.}
 
-\item{subgroup}{Unquoted subgroup aesthetic variable.}
+\item{subgroup}{Unquoted \code{subgroup} aesthetic variable.}
 
-\item{label}{Unquoted label aesthetic variable.}
+\item{label}{Unquoted \code{label} aesthetic variable.}
 
-\item{text}{Unquoted text aesthetic variable.}
+\item{text}{Unquoted \code{text} aesthetic variable.}
 
-\item{sample}{Unquoted sample aesthetic variable.}
+\item{sample}{Unquoted \code{sample} aesthetic variable.}
 
-\item{mapping}{Set of additional aesthetic mappings within the ggplot2::aes function for non-supported aesthetics (e.g. shape, linetype, linewidth, or size) or for delayed evaluation.}
+\item{mapping}{Set of additional aesthetic mappings within \code{ggplot2::aes()} for non-supported aesthetics (e.g. \code{shape}, \code{linetype}, \code{linewidth}, or \code{size}) or for delayed evaluation.}
 
-\item{x_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{x_breaks, y_breaks}{A \verb{scales::breaks_*} function (e.g. \code{\link[scales:breaks_pretty]{scales::breaks_pretty()}}), or a vector of breaks.}
 
-\item{x_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{x_expand, y_expand}{Padding to the limits with the \code{ggplot2::expansion()} function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{x_expand_limits}{For a continuous x variable, any values that the limits should encompass (e.g. 0).}
+\item{x_expand_limits, y_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{x_gridlines}{TRUE or FALSE for vertical x gridlines. NULL guesses based on the classes of the x and y.}
+\item{x_gridlines}{\code{TRUE} or \code{FALSE} for vertical \code{x} gridlines. \code{NULL} guesses based on the classes of the x and y.}
 
-\item{x_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{x_labels, y_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{\link[scales:label_number]{scales::label_comma()}}), or a vector of labels.}
 
-\item{x_limits}{A vector of length 2 to determine the limits of the axis.}
+\item{x_limits, y_limits}{A vector of length 2 to determine the limits of the axis.}
 
-\item{x_oob}{For a continuous x variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{x_oob, y_oob}{For a continuous \code{x} variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
-\item{x_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
+\item{x_sec_axis, y_sec_axis}{A secondary axis using \code{ggplot2::sec_axis()} or \code{ggplot2::dup_axis()}.}
 
-\item{x_title}{Axis title string. Use "" for no title.}
+\item{x_title, y_title}{Axis title string. Use \code{""} for no title.}
 
-\item{x_transform}{For a numeric x variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{x_transform, y_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{y_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{y_gridlines}{\code{TRUE} or \code{FALSE} of horizontal \code{y} gridlines. \code{NULL} guesses based on the classes of the \code{x} and \code{y}.}
 
-\item{y_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
-
-\item{y_expand_limits}{For a continuous y variable, any values that the limits should encompass (e.g. 0).}
-
-\item{y_gridlines}{TRUE or FALSE of horizontal y gridlines. NULL guesses based on the classes of the x and y.}
-
-\item{y_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
-
-\item{y_limits}{A vector of length 2 to determine the limits of the axis.}
-
-\item{y_oob}{For a continuous y variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
-
-\item{y_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
-
-\item{y_title}{Axis title string. Use "" for no title.}
-
-\item{y_transform}{For a numeric y variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
-
-\item{col_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{col_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{col_continuous_type}{For a continuous variable, whether to colour as a "gradient" or in "steps". Defaults to "gradient".}
 
 \item{col_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{col_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{col_expand}{Padding to the limits with \code{ggplot2::expansion()}, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{col_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{col_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{col_legend_ncol}{The number of columns for the legend elements.}
+\item{col_legend_ncol, col_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{col_legend_nrow}{The number of rows for the legend elements.}
-
-\item{col_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{col_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{col_limits}{A vector to determine the limits of the scale.}
 
-\item{col_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{col_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{col_pal}{colours to use. A character vector of hex codes (or names).}
 
-\item{col_pal_na}{colour to use for NA values. A character vector of a hex code (or name).}
+\item{col_pal_na}{colour to use for \code{NA} values. A character vector of a hex code (or name).}
 
-\item{col_rescale}{For a continuous variable, a scales::rescale function.}
+\item{col_rescale}{For a continuous variable, a \code{scales::rescale} function.}
 
 \item{col_title}{Legend title string. Use "" for no title.}
 
-\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{alpha_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{alpha_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{alpha_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{alpha_legend_ncol}{The number of columns for the legend elements.}
+\item{alpha_legend_ncol, alpha_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{alpha_legend_nrow}{The number of rows for the legend elements.}
-
-\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{alpha_limits}{A vector to determine the limits of the scale.}
 
-\item{alpha_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{alpha_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{alpha_pal}{Alpha values to use as a numeric vector. For a continuous variable, a range is only needed.}
 
-\item{alpha_pal_na}{Alpha value to use for the NA value.}
+\item{alpha_pal_na}{Alpha value to use for the \code{NA} value.}
 
-\item{alpha_title}{Legend title string. Use "" for no title.}
+\item{alpha_title}{Legend title string. Use \code{""} for no title.}
 
-\item{alpha_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{alpha_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the transform_ prefix (e.g. "log10").}
 
 \item{facet_axes}{Whether to add interior axes and ticks with "margins", "all", "all_x", or "all_y".}
 
 \item{facet_axis_labels}{Whether to add interior axis labels with "margins", "all", "all_x", or "all_y".}
 
-\item{facet_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
+\item{facet_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
 
 \item{facet_labels_position}{When the facet layout is "wrap", the position of the facet labels. Either "top", "right", "bottom" or "left".}
 
 \item{facet_labels_switch}{When the facet layout is "grid", whether to switch the facet labels to the opposite side of the plot. Either "x", "y" or "both".}
 
-\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If NULL and a single facet (or facet2) argument is provided, then defaults to "wrap". If NULL and both facet and facet2 arguments are provided, defaults to "grid".}
+\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If \code{NULL} and a single \code{facet} (or \code{facet2}) argument is provided, then defaults to "wrap". If \code{NULL} and both facet and facet2 arguments are provided, defaults to "grid".}
 
 \item{facet_ncol}{The number of columns of facets. Only applies to a facet layout of "wrap".}
 
@@ -268,15 +246,15 @@ gg_linerange(
 
 \item{caption}{Caption title string.}
 
-\item{titles}{A function to format unspecified titles. Defaults to snakecase::to_sentence_case.}
+\item{titles}{A function to format unspecified titles. Defaults to \code{snakecase::to_sentence_case}.}
 
-\item{flipped}{TRUE or FALSE or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
+\item{flipped}{\code{TRUE} or \code{FALSE} or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
 }
 \value{
 A ggplot object.
 }
 \description{
-Create a linerange ggplot with a wrapper around ggplot() + geom_linerange.
+Create a linerange ggplot with a wrapper around \code{ggplot()} + \link[ggplot2:geom_linerange]{geom_linerange()}.
 }
 \examples{
 

--- a/man/gg_path.Rd
+++ b/man/gg_path.Rd
@@ -98,161 +98,139 @@ gg_path(
 \arguments{
 \item{data}{A data frame or tibble.}
 
-\item{...}{Other arguments passed to within a params list in the layer function.}
+\item{...}{Other arguments passed to within a \code{params} list in \code{layer()}.}
 
 \item{stat}{A statistical transformation to use on the data. A snakecase character string of a ggproto Stat subclass object minus the Stat prefix (e.g. "identity").}
 
-\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a position_* function that outputs a ggproto Position subclass object (e.g. ggplot2::position_identity()).}
+\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a \verb{position_*()} function that outputs a ggproto Position subclass object (e.g. \code{ggplot2::position_identity()}).}
 
-\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. ggplot2::coord_cartesian()).}
+\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. \code{\link[ggplot2:coord_cartesian]{ggplot2::coord_cartesian()}}).}
 
-\item{theme}{A ggplot2 theme (e.g. light_mode_b(), dark_mode_rt() or ggplot2::theme_grey()).}
+\item{theme}{A ggplot2 theme (e.g. \code{\link[=light_mode_b]{light_mode_b()}}, \code{\link[=dark_mode_rt]{dark_mode_rt()}} or \code{\link[ggplot2:ggtheme]{ggplot2::theme_grey()}}).}
 
-\item{x}{Unquoted x aesthetic variable.}
+\item{x}{Unquoted \code{x} aesthetic variable.}
 
-\item{xmin}{Unquoted xmin aesthetic variable.}
+\item{xmin}{Unquoted \code{xmin} aesthetic variable.}
 
-\item{xmax}{Unquoted xmax aesthetic variable.}
+\item{xmax}{Unquoted \code{xmax} aesthetic variable.}
 
-\item{xend}{Unquoted xend aesthetic variable.}
+\item{xend}{Unquoted \code{xend} aesthetic variable.}
 
-\item{y}{Unquoted y aesthetic variable.}
+\item{y}{Unquoted \code{y} aesthetic variable.}
 
-\item{ymin}{Unquoted ymin aesthetic variable.}
+\item{ymin}{Unquoted \code{ymin} aesthetic variable.}
 
-\item{ymax}{Unquoted ymax aesthetic variable.}
+\item{ymax}{Unquoted \code{ymax} aesthetic variable.}
 
-\item{yend}{Unquoted yend aesthetic variable.}
+\item{yend}{Unquoted \code{yend} aesthetic variable.}
 
-\item{z}{Unquoted z aesthetic variable.}
+\item{z}{Unquoted \code{z} aesthetic variable.}
 
-\item{col}{Unquoted col and fill aesthetic variable.}
+\item{col}{Unquoted \code{col} and \code{fill} aesthetic variable.}
 
-\item{alpha}{Unquoted alpha aesthetic variable.}
+\item{alpha}{Unquoted \code{alpha} aesthetic variable.}
 
-\item{facet}{Unquoted facet aesthetic variable.}
+\item{facet}{Unquoted \code{facet} aesthetic variable.}
 
 \item{facet2}{Unquoted second facet variable.}
 
-\item{group}{Unquoted group aesthetic variable.}
+\item{group}{Unquoted \code{group} aesthetic variable.}
 
-\item{subgroup}{Unquoted subgroup aesthetic variable.}
+\item{subgroup}{Unquoted \code{subgroup} aesthetic variable.}
 
-\item{label}{Unquoted label aesthetic variable.}
+\item{label}{Unquoted \code{label} aesthetic variable.}
 
-\item{text}{Unquoted text aesthetic variable.}
+\item{text}{Unquoted \code{text} aesthetic variable.}
 
-\item{sample}{Unquoted sample aesthetic variable.}
+\item{sample}{Unquoted \code{sample} aesthetic variable.}
 
-\item{mapping}{Set of additional aesthetic mappings within the ggplot2::aes function for non-supported aesthetics (e.g. shape, linetype, linewidth, or size) or for delayed evaluation.}
+\item{mapping}{Set of additional aesthetic mappings within \code{ggplot2::aes()} for non-supported aesthetics (e.g. \code{shape}, \code{linetype}, \code{linewidth}, or \code{size}) or for delayed evaluation.}
 
-\item{x_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{x_breaks, y_breaks}{A \verb{scales::breaks_*} function (e.g. \code{\link[scales:breaks_pretty]{scales::breaks_pretty()}}), or a vector of breaks.}
 
-\item{x_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{x_expand, y_expand}{Padding to the limits with the \code{ggplot2::expansion()} function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{x_expand_limits}{For a continuous x variable, any values that the limits should encompass (e.g. 0).}
+\item{x_expand_limits, y_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{x_gridlines}{TRUE or FALSE for vertical x gridlines. NULL guesses based on the classes of the x and y.}
+\item{x_gridlines}{\code{TRUE} or \code{FALSE} for vertical \code{x} gridlines. \code{NULL} guesses based on the classes of the x and y.}
 
-\item{x_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{x_labels, y_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{\link[scales:label_number]{scales::label_comma()}}), or a vector of labels.}
 
-\item{x_limits}{A vector of length 2 to determine the limits of the axis.}
+\item{x_limits, y_limits}{A vector of length 2 to determine the limits of the axis.}
 
-\item{x_oob}{For a continuous x variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{x_oob, y_oob}{For a continuous \code{x} variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
-\item{x_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
+\item{x_sec_axis, y_sec_axis}{A secondary axis using \code{ggplot2::sec_axis()} or \code{ggplot2::dup_axis()}.}
 
-\item{x_title}{Axis title string. Use "" for no title.}
+\item{x_title, y_title}{Axis title string. Use \code{""} for no title.}
 
-\item{x_transform}{For a numeric x variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{x_transform, y_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{y_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{y_gridlines}{\code{TRUE} or \code{FALSE} of horizontal \code{y} gridlines. \code{NULL} guesses based on the classes of the \code{x} and \code{y}.}
 
-\item{y_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
-
-\item{y_expand_limits}{For a continuous y variable, any values that the limits should encompass (e.g. 0).}
-
-\item{y_gridlines}{TRUE or FALSE of horizontal y gridlines. NULL guesses based on the classes of the x and y.}
-
-\item{y_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
-
-\item{y_limits}{A vector of length 2 to determine the limits of the axis.}
-
-\item{y_oob}{For a continuous y variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
-
-\item{y_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
-
-\item{y_title}{Axis title string. Use "" for no title.}
-
-\item{y_transform}{For a numeric y variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
-
-\item{col_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{col_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{col_continuous_type}{For a continuous variable, whether to colour as a "gradient" or in "steps". Defaults to "gradient".}
 
 \item{col_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{col_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{col_expand}{Padding to the limits with \code{ggplot2::expansion()}, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{col_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{col_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{col_legend_ncol}{The number of columns for the legend elements.}
+\item{col_legend_ncol, col_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{col_legend_nrow}{The number of rows for the legend elements.}
-
-\item{col_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{col_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{col_limits}{A vector to determine the limits of the scale.}
 
-\item{col_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{col_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{col_pal}{colours to use. A character vector of hex codes (or names).}
 
-\item{col_pal_na}{colour to use for NA values. A character vector of a hex code (or name).}
+\item{col_pal_na}{colour to use for \code{NA} values. A character vector of a hex code (or name).}
 
-\item{col_rescale}{For a continuous variable, a scales::rescale function.}
+\item{col_rescale}{For a continuous variable, a \code{scales::rescale} function.}
 
 \item{col_title}{Legend title string. Use "" for no title.}
 
-\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{alpha_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{alpha_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{alpha_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{alpha_legend_ncol}{The number of columns for the legend elements.}
+\item{alpha_legend_ncol, alpha_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{alpha_legend_nrow}{The number of rows for the legend elements.}
-
-\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{alpha_limits}{A vector to determine the limits of the scale.}
 
-\item{alpha_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{alpha_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{alpha_pal}{Alpha values to use as a numeric vector. For a continuous variable, a range is only needed.}
 
-\item{alpha_pal_na}{Alpha value to use for the NA value.}
+\item{alpha_pal_na}{Alpha value to use for the \code{NA} value.}
 
-\item{alpha_title}{Legend title string. Use "" for no title.}
+\item{alpha_title}{Legend title string. Use \code{""} for no title.}
 
-\item{alpha_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{alpha_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the transform_ prefix (e.g. "log10").}
 
 \item{facet_axes}{Whether to add interior axes and ticks with "margins", "all", "all_x", or "all_y".}
 
 \item{facet_axis_labels}{Whether to add interior axis labels with "margins", "all", "all_x", or "all_y".}
 
-\item{facet_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
+\item{facet_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
 
 \item{facet_labels_position}{When the facet layout is "wrap", the position of the facet labels. Either "top", "right", "bottom" or "left".}
 
 \item{facet_labels_switch}{When the facet layout is "grid", whether to switch the facet labels to the opposite side of the plot. Either "x", "y" or "both".}
 
-\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If NULL and a single facet (or facet2) argument is provided, then defaults to "wrap". If NULL and both facet and facet2 arguments are provided, defaults to "grid".}
+\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If \code{NULL} and a single \code{facet} (or \code{facet2}) argument is provided, then defaults to "wrap". If \code{NULL} and both facet and facet2 arguments are provided, defaults to "grid".}
 
 \item{facet_ncol}{The number of columns of facets. Only applies to a facet layout of "wrap".}
 
@@ -268,15 +246,15 @@ gg_path(
 
 \item{caption}{Caption title string.}
 
-\item{titles}{A function to format unspecified titles. Defaults to snakecase::to_sentence_case.}
+\item{titles}{A function to format unspecified titles. Defaults to \code{snakecase::to_sentence_case}.}
 
-\item{flipped}{TRUE or FALSE or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
+\item{flipped}{\code{TRUE} or \code{FALSE} or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
 }
 \value{
 A ggplot object.
 }
 \description{
-Create a path ggplot with a wrapper around ggplot() + geom_path.
+Create a path ggplot with a wrapper around \code{ggplot()} + \link[ggplot2:geom_path]{geom_path()}.
 }
 \examples{
 

--- a/man/gg_point.Rd
+++ b/man/gg_point.Rd
@@ -98,161 +98,139 @@ gg_point(
 \arguments{
 \item{data}{A data frame or tibble.}
 
-\item{...}{Other arguments passed to within a params list in the layer function.}
+\item{...}{Other arguments passed to within a \code{params} list in \code{layer()}.}
 
 \item{stat}{A statistical transformation to use on the data. A snakecase character string of a ggproto Stat subclass object minus the Stat prefix (e.g. "identity").}
 
-\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a position_* function that outputs a ggproto Position subclass object (e.g. ggplot2::position_identity()).}
+\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a \verb{position_*()} function that outputs a ggproto Position subclass object (e.g. \code{ggplot2::position_identity()}).}
 
-\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. ggplot2::coord_cartesian()).}
+\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. \code{\link[ggplot2:coord_cartesian]{ggplot2::coord_cartesian()}}).}
 
-\item{theme}{A ggplot2 theme (e.g. light_mode_b(), dark_mode_rt() or ggplot2::theme_grey()).}
+\item{theme}{A ggplot2 theme (e.g. \code{\link[=light_mode_b]{light_mode_b()}}, \code{\link[=dark_mode_rt]{dark_mode_rt()}} or \code{\link[ggplot2:ggtheme]{ggplot2::theme_grey()}}).}
 
-\item{x}{Unquoted x aesthetic variable.}
+\item{x}{Unquoted \code{x} aesthetic variable.}
 
-\item{xmin}{Unquoted xmin aesthetic variable.}
+\item{xmin}{Unquoted \code{xmin} aesthetic variable.}
 
-\item{xmax}{Unquoted xmax aesthetic variable.}
+\item{xmax}{Unquoted \code{xmax} aesthetic variable.}
 
-\item{xend}{Unquoted xend aesthetic variable.}
+\item{xend}{Unquoted \code{xend} aesthetic variable.}
 
-\item{y}{Unquoted y aesthetic variable.}
+\item{y}{Unquoted \code{y} aesthetic variable.}
 
-\item{ymin}{Unquoted ymin aesthetic variable.}
+\item{ymin}{Unquoted \code{ymin} aesthetic variable.}
 
-\item{ymax}{Unquoted ymax aesthetic variable.}
+\item{ymax}{Unquoted \code{ymax} aesthetic variable.}
 
-\item{yend}{Unquoted yend aesthetic variable.}
+\item{yend}{Unquoted \code{yend} aesthetic variable.}
 
-\item{z}{Unquoted z aesthetic variable.}
+\item{z}{Unquoted \code{z} aesthetic variable.}
 
-\item{col}{Unquoted col and fill aesthetic variable.}
+\item{col}{Unquoted \code{col} and \code{fill} aesthetic variable.}
 
-\item{alpha}{Unquoted alpha aesthetic variable.}
+\item{alpha}{Unquoted \code{alpha} aesthetic variable.}
 
-\item{facet}{Unquoted facet aesthetic variable.}
+\item{facet}{Unquoted \code{facet} aesthetic variable.}
 
 \item{facet2}{Unquoted second facet variable.}
 
-\item{group}{Unquoted group aesthetic variable.}
+\item{group}{Unquoted \code{group} aesthetic variable.}
 
-\item{subgroup}{Unquoted subgroup aesthetic variable.}
+\item{subgroup}{Unquoted \code{subgroup} aesthetic variable.}
 
-\item{label}{Unquoted label aesthetic variable.}
+\item{label}{Unquoted \code{label} aesthetic variable.}
 
-\item{text}{Unquoted text aesthetic variable.}
+\item{text}{Unquoted \code{text} aesthetic variable.}
 
-\item{sample}{Unquoted sample aesthetic variable.}
+\item{sample}{Unquoted \code{sample} aesthetic variable.}
 
-\item{mapping}{Set of additional aesthetic mappings within the ggplot2::aes function for non-supported aesthetics (e.g. shape, linetype, linewidth, or size) or for delayed evaluation.}
+\item{mapping}{Set of additional aesthetic mappings within \code{ggplot2::aes()} for non-supported aesthetics (e.g. \code{shape}, \code{linetype}, \code{linewidth}, or \code{size}) or for delayed evaluation.}
 
-\item{x_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{x_breaks, y_breaks}{A \verb{scales::breaks_*} function (e.g. \code{\link[scales:breaks_pretty]{scales::breaks_pretty()}}), or a vector of breaks.}
 
-\item{x_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{x_expand, y_expand}{Padding to the limits with the \code{ggplot2::expansion()} function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{x_expand_limits}{For a continuous x variable, any values that the limits should encompass (e.g. 0).}
+\item{x_expand_limits, y_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{x_gridlines}{TRUE or FALSE for vertical x gridlines. NULL guesses based on the classes of the x and y.}
+\item{x_gridlines}{\code{TRUE} or \code{FALSE} for vertical \code{x} gridlines. \code{NULL} guesses based on the classes of the x and y.}
 
-\item{x_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{x_labels, y_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{\link[scales:label_number]{scales::label_comma()}}), or a vector of labels.}
 
-\item{x_limits}{A vector of length 2 to determine the limits of the axis.}
+\item{x_limits, y_limits}{A vector of length 2 to determine the limits of the axis.}
 
-\item{x_oob}{For a continuous x variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{x_oob, y_oob}{For a continuous \code{x} variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
-\item{x_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
+\item{x_sec_axis, y_sec_axis}{A secondary axis using \code{ggplot2::sec_axis()} or \code{ggplot2::dup_axis()}.}
 
-\item{x_title}{Axis title string. Use "" for no title.}
+\item{x_title, y_title}{Axis title string. Use \code{""} for no title.}
 
-\item{x_transform}{For a numeric x variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{x_transform, y_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{y_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{y_gridlines}{\code{TRUE} or \code{FALSE} of horizontal \code{y} gridlines. \code{NULL} guesses based on the classes of the \code{x} and \code{y}.}
 
-\item{y_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
-
-\item{y_expand_limits}{For a continuous y variable, any values that the limits should encompass (e.g. 0).}
-
-\item{y_gridlines}{TRUE or FALSE of horizontal y gridlines. NULL guesses based on the classes of the x and y.}
-
-\item{y_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
-
-\item{y_limits}{A vector of length 2 to determine the limits of the axis.}
-
-\item{y_oob}{For a continuous y variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
-
-\item{y_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
-
-\item{y_title}{Axis title string. Use "" for no title.}
-
-\item{y_transform}{For a numeric y variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
-
-\item{col_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{col_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{col_continuous_type}{For a continuous variable, whether to colour as a "gradient" or in "steps". Defaults to "gradient".}
 
 \item{col_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{col_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{col_expand}{Padding to the limits with \code{ggplot2::expansion()}, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{col_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{col_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{col_legend_ncol}{The number of columns for the legend elements.}
+\item{col_legend_ncol, col_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{col_legend_nrow}{The number of rows for the legend elements.}
-
-\item{col_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{col_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{col_limits}{A vector to determine the limits of the scale.}
 
-\item{col_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{col_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{col_pal}{colours to use. A character vector of hex codes (or names).}
 
-\item{col_pal_na}{colour to use for NA values. A character vector of a hex code (or name).}
+\item{col_pal_na}{colour to use for \code{NA} values. A character vector of a hex code (or name).}
 
-\item{col_rescale}{For a continuous variable, a scales::rescale function.}
+\item{col_rescale}{For a continuous variable, a \code{scales::rescale} function.}
 
 \item{col_title}{Legend title string. Use "" for no title.}
 
-\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{alpha_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{alpha_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{alpha_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{alpha_legend_ncol}{The number of columns for the legend elements.}
+\item{alpha_legend_ncol, alpha_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{alpha_legend_nrow}{The number of rows for the legend elements.}
-
-\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{alpha_limits}{A vector to determine the limits of the scale.}
 
-\item{alpha_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{alpha_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{alpha_pal}{Alpha values to use as a numeric vector. For a continuous variable, a range is only needed.}
 
-\item{alpha_pal_na}{Alpha value to use for the NA value.}
+\item{alpha_pal_na}{Alpha value to use for the \code{NA} value.}
 
-\item{alpha_title}{Legend title string. Use "" for no title.}
+\item{alpha_title}{Legend title string. Use \code{""} for no title.}
 
-\item{alpha_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{alpha_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the transform_ prefix (e.g. "log10").}
 
 \item{facet_axes}{Whether to add interior axes and ticks with "margins", "all", "all_x", or "all_y".}
 
 \item{facet_axis_labels}{Whether to add interior axis labels with "margins", "all", "all_x", or "all_y".}
 
-\item{facet_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
+\item{facet_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
 
 \item{facet_labels_position}{When the facet layout is "wrap", the position of the facet labels. Either "top", "right", "bottom" or "left".}
 
 \item{facet_labels_switch}{When the facet layout is "grid", whether to switch the facet labels to the opposite side of the plot. Either "x", "y" or "both".}
 
-\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If NULL and a single facet (or facet2) argument is provided, then defaults to "wrap". If NULL and both facet and facet2 arguments are provided, defaults to "grid".}
+\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If \code{NULL} and a single \code{facet} (or \code{facet2}) argument is provided, then defaults to "wrap". If \code{NULL} and both facet and facet2 arguments are provided, defaults to "grid".}
 
 \item{facet_ncol}{The number of columns of facets. Only applies to a facet layout of "wrap".}
 
@@ -268,15 +246,15 @@ gg_point(
 
 \item{caption}{Caption title string.}
 
-\item{titles}{A function to format unspecified titles. Defaults to snakecase::to_sentence_case.}
+\item{titles}{A function to format unspecified titles. Defaults to \code{snakecase::to_sentence_case}.}
 
-\item{flipped}{TRUE or FALSE or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
+\item{flipped}{\code{TRUE} or \code{FALSE} or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
 }
 \value{
 A ggplot object.
 }
 \description{
-Create a point ggplot with a wrapper around ggplot() + geom_point.
+Create a point ggplot with a wrapper around \code{ggplot()} + \link[ggplot2:geom_point]{geom_point()}.
 }
 \examples{
 

--- a/man/gg_pointrange.Rd
+++ b/man/gg_pointrange.Rd
@@ -98,161 +98,139 @@ gg_pointrange(
 \arguments{
 \item{data}{A data frame or tibble.}
 
-\item{...}{Other arguments passed to within a params list in the layer function.}
+\item{...}{Other arguments passed to within a \code{params} list in \code{layer()}.}
 
 \item{stat}{A statistical transformation to use on the data. A snakecase character string of a ggproto Stat subclass object minus the Stat prefix (e.g. "identity").}
 
-\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a position_* function that outputs a ggproto Position subclass object (e.g. ggplot2::position_identity()).}
+\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a \verb{position_*()} function that outputs a ggproto Position subclass object (e.g. \code{ggplot2::position_identity()}).}
 
-\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. ggplot2::coord_cartesian()).}
+\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. \code{\link[ggplot2:coord_cartesian]{ggplot2::coord_cartesian()}}).}
 
-\item{theme}{A ggplot2 theme (e.g. light_mode_b(), dark_mode_rt() or ggplot2::theme_grey()).}
+\item{theme}{A ggplot2 theme (e.g. \code{\link[=light_mode_b]{light_mode_b()}}, \code{\link[=dark_mode_rt]{dark_mode_rt()}} or \code{\link[ggplot2:ggtheme]{ggplot2::theme_grey()}}).}
 
-\item{x}{Unquoted x aesthetic variable.}
+\item{x}{Unquoted \code{x} aesthetic variable.}
 
-\item{xmin}{Unquoted xmin aesthetic variable.}
+\item{xmin}{Unquoted \code{xmin} aesthetic variable.}
 
-\item{xmax}{Unquoted xmax aesthetic variable.}
+\item{xmax}{Unquoted \code{xmax} aesthetic variable.}
 
-\item{xend}{Unquoted xend aesthetic variable.}
+\item{xend}{Unquoted \code{xend} aesthetic variable.}
 
-\item{y}{Unquoted y aesthetic variable.}
+\item{y}{Unquoted \code{y} aesthetic variable.}
 
-\item{ymin}{Unquoted ymin aesthetic variable.}
+\item{ymin}{Unquoted \code{ymin} aesthetic variable.}
 
-\item{ymax}{Unquoted ymax aesthetic variable.}
+\item{ymax}{Unquoted \code{ymax} aesthetic variable.}
 
-\item{yend}{Unquoted yend aesthetic variable.}
+\item{yend}{Unquoted \code{yend} aesthetic variable.}
 
-\item{z}{Unquoted z aesthetic variable.}
+\item{z}{Unquoted \code{z} aesthetic variable.}
 
-\item{col}{Unquoted col and fill aesthetic variable.}
+\item{col}{Unquoted \code{col} and \code{fill} aesthetic variable.}
 
-\item{alpha}{Unquoted alpha aesthetic variable.}
+\item{alpha}{Unquoted \code{alpha} aesthetic variable.}
 
-\item{facet}{Unquoted facet aesthetic variable.}
+\item{facet}{Unquoted \code{facet} aesthetic variable.}
 
 \item{facet2}{Unquoted second facet variable.}
 
-\item{group}{Unquoted group aesthetic variable.}
+\item{group}{Unquoted \code{group} aesthetic variable.}
 
-\item{subgroup}{Unquoted subgroup aesthetic variable.}
+\item{subgroup}{Unquoted \code{subgroup} aesthetic variable.}
 
-\item{label}{Unquoted label aesthetic variable.}
+\item{label}{Unquoted \code{label} aesthetic variable.}
 
-\item{text}{Unquoted text aesthetic variable.}
+\item{text}{Unquoted \code{text} aesthetic variable.}
 
-\item{sample}{Unquoted sample aesthetic variable.}
+\item{sample}{Unquoted \code{sample} aesthetic variable.}
 
-\item{mapping}{Set of additional aesthetic mappings within the ggplot2::aes function for non-supported aesthetics (e.g. shape, linetype, linewidth, or size) or for delayed evaluation.}
+\item{mapping}{Set of additional aesthetic mappings within \code{ggplot2::aes()} for non-supported aesthetics (e.g. \code{shape}, \code{linetype}, \code{linewidth}, or \code{size}) or for delayed evaluation.}
 
-\item{x_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{x_breaks, y_breaks}{A \verb{scales::breaks_*} function (e.g. \code{\link[scales:breaks_pretty]{scales::breaks_pretty()}}), or a vector of breaks.}
 
-\item{x_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{x_expand, y_expand}{Padding to the limits with the \code{ggplot2::expansion()} function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{x_expand_limits}{For a continuous x variable, any values that the limits should encompass (e.g. 0).}
+\item{x_expand_limits, y_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{x_gridlines}{TRUE or FALSE for vertical x gridlines. NULL guesses based on the classes of the x and y.}
+\item{x_gridlines}{\code{TRUE} or \code{FALSE} for vertical \code{x} gridlines. \code{NULL} guesses based on the classes of the x and y.}
 
-\item{x_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{x_labels, y_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{\link[scales:label_number]{scales::label_comma()}}), or a vector of labels.}
 
-\item{x_limits}{A vector of length 2 to determine the limits of the axis.}
+\item{x_limits, y_limits}{A vector of length 2 to determine the limits of the axis.}
 
-\item{x_oob}{For a continuous x variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{x_oob, y_oob}{For a continuous \code{x} variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
-\item{x_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
+\item{x_sec_axis, y_sec_axis}{A secondary axis using \code{ggplot2::sec_axis()} or \code{ggplot2::dup_axis()}.}
 
-\item{x_title}{Axis title string. Use "" for no title.}
+\item{x_title, y_title}{Axis title string. Use \code{""} for no title.}
 
-\item{x_transform}{For a numeric x variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{x_transform, y_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{y_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{y_gridlines}{\code{TRUE} or \code{FALSE} of horizontal \code{y} gridlines. \code{NULL} guesses based on the classes of the \code{x} and \code{y}.}
 
-\item{y_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
-
-\item{y_expand_limits}{For a continuous y variable, any values that the limits should encompass (e.g. 0).}
-
-\item{y_gridlines}{TRUE or FALSE of horizontal y gridlines. NULL guesses based on the classes of the x and y.}
-
-\item{y_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
-
-\item{y_limits}{A vector of length 2 to determine the limits of the axis.}
-
-\item{y_oob}{For a continuous y variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
-
-\item{y_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
-
-\item{y_title}{Axis title string. Use "" for no title.}
-
-\item{y_transform}{For a numeric y variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
-
-\item{col_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{col_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{col_continuous_type}{For a continuous variable, whether to colour as a "gradient" or in "steps". Defaults to "gradient".}
 
 \item{col_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{col_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{col_expand}{Padding to the limits with \code{ggplot2::expansion()}, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{col_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{col_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{col_legend_ncol}{The number of columns for the legend elements.}
+\item{col_legend_ncol, col_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{col_legend_nrow}{The number of rows for the legend elements.}
-
-\item{col_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{col_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{col_limits}{A vector to determine the limits of the scale.}
 
-\item{col_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{col_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{col_pal}{colours to use. A character vector of hex codes (or names).}
 
-\item{col_pal_na}{colour to use for NA values. A character vector of a hex code (or name).}
+\item{col_pal_na}{colour to use for \code{NA} values. A character vector of a hex code (or name).}
 
-\item{col_rescale}{For a continuous variable, a scales::rescale function.}
+\item{col_rescale}{For a continuous variable, a \code{scales::rescale} function.}
 
 \item{col_title}{Legend title string. Use "" for no title.}
 
-\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{alpha_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{alpha_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{alpha_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{alpha_legend_ncol}{The number of columns for the legend elements.}
+\item{alpha_legend_ncol, alpha_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{alpha_legend_nrow}{The number of rows for the legend elements.}
-
-\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{alpha_limits}{A vector to determine the limits of the scale.}
 
-\item{alpha_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{alpha_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{alpha_pal}{Alpha values to use as a numeric vector. For a continuous variable, a range is only needed.}
 
-\item{alpha_pal_na}{Alpha value to use for the NA value.}
+\item{alpha_pal_na}{Alpha value to use for the \code{NA} value.}
 
-\item{alpha_title}{Legend title string. Use "" for no title.}
+\item{alpha_title}{Legend title string. Use \code{""} for no title.}
 
-\item{alpha_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{alpha_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the transform_ prefix (e.g. "log10").}
 
 \item{facet_axes}{Whether to add interior axes and ticks with "margins", "all", "all_x", or "all_y".}
 
 \item{facet_axis_labels}{Whether to add interior axis labels with "margins", "all", "all_x", or "all_y".}
 
-\item{facet_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
+\item{facet_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
 
 \item{facet_labels_position}{When the facet layout is "wrap", the position of the facet labels. Either "top", "right", "bottom" or "left".}
 
 \item{facet_labels_switch}{When the facet layout is "grid", whether to switch the facet labels to the opposite side of the plot. Either "x", "y" or "both".}
 
-\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If NULL and a single facet (or facet2) argument is provided, then defaults to "wrap". If NULL and both facet and facet2 arguments are provided, defaults to "grid".}
+\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If \code{NULL} and a single \code{facet} (or \code{facet2}) argument is provided, then defaults to "wrap". If \code{NULL} and both facet and facet2 arguments are provided, defaults to "grid".}
 
 \item{facet_ncol}{The number of columns of facets. Only applies to a facet layout of "wrap".}
 
@@ -268,15 +246,15 @@ gg_pointrange(
 
 \item{caption}{Caption title string.}
 
-\item{titles}{A function to format unspecified titles. Defaults to snakecase::to_sentence_case.}
+\item{titles}{A function to format unspecified titles. Defaults to \code{snakecase::to_sentence_case}.}
 
-\item{flipped}{TRUE or FALSE or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
+\item{flipped}{\code{TRUE} or \code{FALSE} or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
 }
 \value{
 A ggplot object.
 }
 \description{
-Create a pointrange ggplot with a wrapper around ggplot() + geom_pointrange.
+Create a pointrange ggplot with a wrapper around \code{ggplot()} + \link[ggplot2:geom_linerange]{geom_pointrange()}.
 }
 \examples{
 

--- a/man/gg_polygon.Rd
+++ b/man/gg_polygon.Rd
@@ -98,161 +98,139 @@ gg_polygon(
 \arguments{
 \item{data}{A data frame or tibble.}
 
-\item{...}{Other arguments passed to within a params list in the layer function.}
+\item{...}{Other arguments passed to within a \code{params} list in \code{layer()}.}
 
 \item{stat}{A statistical transformation to use on the data. A snakecase character string of a ggproto Stat subclass object minus the Stat prefix (e.g. "identity").}
 
-\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a position_* function that outputs a ggproto Position subclass object (e.g. ggplot2::position_identity()).}
+\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a \verb{position_*()} function that outputs a ggproto Position subclass object (e.g. \code{ggplot2::position_identity()}).}
 
-\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. ggplot2::coord_cartesian()).}
+\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. \code{\link[ggplot2:coord_cartesian]{ggplot2::coord_cartesian()}}).}
 
-\item{theme}{A ggplot2 theme (e.g. light_mode_b(), dark_mode_rt() or ggplot2::theme_grey()).}
+\item{theme}{A ggplot2 theme (e.g. \code{\link[=light_mode_b]{light_mode_b()}}, \code{\link[=dark_mode_rt]{dark_mode_rt()}} or \code{\link[ggplot2:ggtheme]{ggplot2::theme_grey()}}).}
 
-\item{x}{Unquoted x aesthetic variable.}
+\item{x}{Unquoted \code{x} aesthetic variable.}
 
-\item{xmin}{Unquoted xmin aesthetic variable.}
+\item{xmin}{Unquoted \code{xmin} aesthetic variable.}
 
-\item{xmax}{Unquoted xmax aesthetic variable.}
+\item{xmax}{Unquoted \code{xmax} aesthetic variable.}
 
-\item{xend}{Unquoted xend aesthetic variable.}
+\item{xend}{Unquoted \code{xend} aesthetic variable.}
 
-\item{y}{Unquoted y aesthetic variable.}
+\item{y}{Unquoted \code{y} aesthetic variable.}
 
-\item{ymin}{Unquoted ymin aesthetic variable.}
+\item{ymin}{Unquoted \code{ymin} aesthetic variable.}
 
-\item{ymax}{Unquoted ymax aesthetic variable.}
+\item{ymax}{Unquoted \code{ymax} aesthetic variable.}
 
-\item{yend}{Unquoted yend aesthetic variable.}
+\item{yend}{Unquoted \code{yend} aesthetic variable.}
 
-\item{z}{Unquoted z aesthetic variable.}
+\item{z}{Unquoted \code{z} aesthetic variable.}
 
-\item{col}{Unquoted col and fill aesthetic variable.}
+\item{col}{Unquoted \code{col} and \code{fill} aesthetic variable.}
 
-\item{alpha}{Unquoted alpha aesthetic variable.}
+\item{alpha}{Unquoted \code{alpha} aesthetic variable.}
 
-\item{facet}{Unquoted facet aesthetic variable.}
+\item{facet}{Unquoted \code{facet} aesthetic variable.}
 
 \item{facet2}{Unquoted second facet variable.}
 
-\item{group}{Unquoted group aesthetic variable.}
+\item{group}{Unquoted \code{group} aesthetic variable.}
 
-\item{subgroup}{Unquoted subgroup aesthetic variable.}
+\item{subgroup}{Unquoted \code{subgroup} aesthetic variable.}
 
-\item{label}{Unquoted label aesthetic variable.}
+\item{label}{Unquoted \code{label} aesthetic variable.}
 
-\item{text}{Unquoted text aesthetic variable.}
+\item{text}{Unquoted \code{text} aesthetic variable.}
 
-\item{sample}{Unquoted sample aesthetic variable.}
+\item{sample}{Unquoted \code{sample} aesthetic variable.}
 
-\item{mapping}{Set of additional aesthetic mappings within the ggplot2::aes function for non-supported aesthetics (e.g. shape, linetype, linewidth, or size) or for delayed evaluation.}
+\item{mapping}{Set of additional aesthetic mappings within \code{ggplot2::aes()} for non-supported aesthetics (e.g. \code{shape}, \code{linetype}, \code{linewidth}, or \code{size}) or for delayed evaluation.}
 
-\item{x_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{x_breaks, y_breaks}{A \verb{scales::breaks_*} function (e.g. \code{\link[scales:breaks_pretty]{scales::breaks_pretty()}}), or a vector of breaks.}
 
-\item{x_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{x_expand, y_expand}{Padding to the limits with the \code{ggplot2::expansion()} function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{x_expand_limits}{For a continuous x variable, any values that the limits should encompass (e.g. 0).}
+\item{x_expand_limits, y_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{x_gridlines}{TRUE or FALSE for vertical x gridlines. NULL guesses based on the classes of the x and y.}
+\item{x_gridlines}{\code{TRUE} or \code{FALSE} for vertical \code{x} gridlines. \code{NULL} guesses based on the classes of the x and y.}
 
-\item{x_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{x_labels, y_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{\link[scales:label_number]{scales::label_comma()}}), or a vector of labels.}
 
-\item{x_limits}{A vector of length 2 to determine the limits of the axis.}
+\item{x_limits, y_limits}{A vector of length 2 to determine the limits of the axis.}
 
-\item{x_oob}{For a continuous x variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{x_oob, y_oob}{For a continuous \code{x} variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
-\item{x_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
+\item{x_sec_axis, y_sec_axis}{A secondary axis using \code{ggplot2::sec_axis()} or \code{ggplot2::dup_axis()}.}
 
-\item{x_title}{Axis title string. Use "" for no title.}
+\item{x_title, y_title}{Axis title string. Use \code{""} for no title.}
 
-\item{x_transform}{For a numeric x variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{x_transform, y_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{y_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{y_gridlines}{\code{TRUE} or \code{FALSE} of horizontal \code{y} gridlines. \code{NULL} guesses based on the classes of the \code{x} and \code{y}.}
 
-\item{y_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
-
-\item{y_expand_limits}{For a continuous y variable, any values that the limits should encompass (e.g. 0).}
-
-\item{y_gridlines}{TRUE or FALSE of horizontal y gridlines. NULL guesses based on the classes of the x and y.}
-
-\item{y_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
-
-\item{y_limits}{A vector of length 2 to determine the limits of the axis.}
-
-\item{y_oob}{For a continuous y variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
-
-\item{y_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
-
-\item{y_title}{Axis title string. Use "" for no title.}
-
-\item{y_transform}{For a numeric y variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
-
-\item{col_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{col_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{col_continuous_type}{For a continuous variable, whether to colour as a "gradient" or in "steps". Defaults to "gradient".}
 
 \item{col_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{col_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{col_expand}{Padding to the limits with \code{ggplot2::expansion()}, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{col_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{col_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{col_legend_ncol}{The number of columns for the legend elements.}
+\item{col_legend_ncol, col_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{col_legend_nrow}{The number of rows for the legend elements.}
-
-\item{col_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{col_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{col_limits}{A vector to determine the limits of the scale.}
 
-\item{col_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{col_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{col_pal}{colours to use. A character vector of hex codes (or names).}
 
-\item{col_pal_na}{colour to use for NA values. A character vector of a hex code (or name).}
+\item{col_pal_na}{colour to use for \code{NA} values. A character vector of a hex code (or name).}
 
-\item{col_rescale}{For a continuous variable, a scales::rescale function.}
+\item{col_rescale}{For a continuous variable, a \code{scales::rescale} function.}
 
 \item{col_title}{Legend title string. Use "" for no title.}
 
-\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{alpha_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{alpha_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{alpha_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{alpha_legend_ncol}{The number of columns for the legend elements.}
+\item{alpha_legend_ncol, alpha_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{alpha_legend_nrow}{The number of rows for the legend elements.}
-
-\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{alpha_limits}{A vector to determine the limits of the scale.}
 
-\item{alpha_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{alpha_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{alpha_pal}{Alpha values to use as a numeric vector. For a continuous variable, a range is only needed.}
 
-\item{alpha_pal_na}{Alpha value to use for the NA value.}
+\item{alpha_pal_na}{Alpha value to use for the \code{NA} value.}
 
-\item{alpha_title}{Legend title string. Use "" for no title.}
+\item{alpha_title}{Legend title string. Use \code{""} for no title.}
 
-\item{alpha_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{alpha_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the transform_ prefix (e.g. "log10").}
 
 \item{facet_axes}{Whether to add interior axes and ticks with "margins", "all", "all_x", or "all_y".}
 
 \item{facet_axis_labels}{Whether to add interior axis labels with "margins", "all", "all_x", or "all_y".}
 
-\item{facet_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
+\item{facet_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
 
 \item{facet_labels_position}{When the facet layout is "wrap", the position of the facet labels. Either "top", "right", "bottom" or "left".}
 
 \item{facet_labels_switch}{When the facet layout is "grid", whether to switch the facet labels to the opposite side of the plot. Either "x", "y" or "both".}
 
-\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If NULL and a single facet (or facet2) argument is provided, then defaults to "wrap". If NULL and both facet and facet2 arguments are provided, defaults to "grid".}
+\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If \code{NULL} and a single \code{facet} (or \code{facet2}) argument is provided, then defaults to "wrap". If \code{NULL} and both facet and facet2 arguments are provided, defaults to "grid".}
 
 \item{facet_ncol}{The number of columns of facets. Only applies to a facet layout of "wrap".}
 
@@ -268,15 +246,15 @@ gg_polygon(
 
 \item{caption}{Caption title string.}
 
-\item{titles}{A function to format unspecified titles. Defaults to snakecase::to_sentence_case.}
+\item{titles}{A function to format unspecified titles. Defaults to \code{snakecase::to_sentence_case}.}
 
-\item{flipped}{TRUE or FALSE or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
+\item{flipped}{\code{TRUE} or \code{FALSE} or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
 }
 \value{
 A ggplot object.
 }
 \description{
-Create a polygon ggplot with a wrapper around ggplot() + geom_polygon.
+Create a polygon ggplot with a wrapper around \code{ggplot()} + \link[ggplot2:geom_polygon]{geom_polygon()}.
 }
 \examples{
 

--- a/man/gg_qq.Rd
+++ b/man/gg_qq.Rd
@@ -98,161 +98,139 @@ gg_qq(
 \arguments{
 \item{data}{A data frame or tibble.}
 
-\item{...}{Other arguments passed to within a params list in the layer function.}
+\item{...}{Other arguments passed to within a \code{params} list in \code{layer()}.}
 
 \item{stat}{A statistical transformation to use on the data. A snakecase character string of a ggproto Stat subclass object minus the Stat prefix (e.g. "identity").}
 
-\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a position_* function that outputs a ggproto Position subclass object (e.g. ggplot2::position_identity()).}
+\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a \verb{position_*()} function that outputs a ggproto Position subclass object (e.g. \code{ggplot2::position_identity()}).}
 
-\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. ggplot2::coord_cartesian()).}
+\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. \code{\link[ggplot2:coord_cartesian]{ggplot2::coord_cartesian()}}).}
 
-\item{theme}{A ggplot2 theme (e.g. light_mode_b(), dark_mode_rt() or ggplot2::theme_grey()).}
+\item{theme}{A ggplot2 theme (e.g. \code{\link[=light_mode_b]{light_mode_b()}}, \code{\link[=dark_mode_rt]{dark_mode_rt()}} or \code{\link[ggplot2:ggtheme]{ggplot2::theme_grey()}}).}
 
-\item{x}{Unquoted x aesthetic variable.}
+\item{x}{Unquoted \code{x} aesthetic variable.}
 
-\item{xmin}{Unquoted xmin aesthetic variable.}
+\item{xmin}{Unquoted \code{xmin} aesthetic variable.}
 
-\item{xmax}{Unquoted xmax aesthetic variable.}
+\item{xmax}{Unquoted \code{xmax} aesthetic variable.}
 
-\item{xend}{Unquoted xend aesthetic variable.}
+\item{xend}{Unquoted \code{xend} aesthetic variable.}
 
-\item{y}{Unquoted y aesthetic variable.}
+\item{y}{Unquoted \code{y} aesthetic variable.}
 
-\item{ymin}{Unquoted ymin aesthetic variable.}
+\item{ymin}{Unquoted \code{ymin} aesthetic variable.}
 
-\item{ymax}{Unquoted ymax aesthetic variable.}
+\item{ymax}{Unquoted \code{ymax} aesthetic variable.}
 
-\item{yend}{Unquoted yend aesthetic variable.}
+\item{yend}{Unquoted \code{yend} aesthetic variable.}
 
-\item{z}{Unquoted z aesthetic variable.}
+\item{z}{Unquoted \code{z} aesthetic variable.}
 
-\item{col}{Unquoted col and fill aesthetic variable.}
+\item{col}{Unquoted \code{col} and \code{fill} aesthetic variable.}
 
-\item{alpha}{Unquoted alpha aesthetic variable.}
+\item{alpha}{Unquoted \code{alpha} aesthetic variable.}
 
-\item{facet}{Unquoted facet aesthetic variable.}
+\item{facet}{Unquoted \code{facet} aesthetic variable.}
 
 \item{facet2}{Unquoted second facet variable.}
 
-\item{group}{Unquoted group aesthetic variable.}
+\item{group}{Unquoted \code{group} aesthetic variable.}
 
-\item{subgroup}{Unquoted subgroup aesthetic variable.}
+\item{subgroup}{Unquoted \code{subgroup} aesthetic variable.}
 
-\item{label}{Unquoted label aesthetic variable.}
+\item{label}{Unquoted \code{label} aesthetic variable.}
 
-\item{text}{Unquoted text aesthetic variable.}
+\item{text}{Unquoted \code{text} aesthetic variable.}
 
-\item{sample}{Unquoted sample aesthetic variable.}
+\item{sample}{Unquoted \code{sample} aesthetic variable.}
 
-\item{mapping}{Set of additional aesthetic mappings within the ggplot2::aes function for non-supported aesthetics (e.g. shape, linetype, linewidth, or size) or for delayed evaluation.}
+\item{mapping}{Set of additional aesthetic mappings within \code{ggplot2::aes()} for non-supported aesthetics (e.g. \code{shape}, \code{linetype}, \code{linewidth}, or \code{size}) or for delayed evaluation.}
 
-\item{x_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{x_breaks, y_breaks}{A \verb{scales::breaks_*} function (e.g. \code{\link[scales:breaks_pretty]{scales::breaks_pretty()}}), or a vector of breaks.}
 
-\item{x_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{x_expand, y_expand}{Padding to the limits with the \code{ggplot2::expansion()} function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{x_expand_limits}{For a continuous x variable, any values that the limits should encompass (e.g. 0).}
+\item{x_expand_limits, y_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{x_gridlines}{TRUE or FALSE for vertical x gridlines. NULL guesses based on the classes of the x and y.}
+\item{x_gridlines}{\code{TRUE} or \code{FALSE} for vertical \code{x} gridlines. \code{NULL} guesses based on the classes of the x and y.}
 
-\item{x_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{x_labels, y_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{\link[scales:label_number]{scales::label_comma()}}), or a vector of labels.}
 
-\item{x_limits}{A vector of length 2 to determine the limits of the axis.}
+\item{x_limits, y_limits}{A vector of length 2 to determine the limits of the axis.}
 
-\item{x_oob}{For a continuous x variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{x_oob, y_oob}{For a continuous \code{x} variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
-\item{x_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
+\item{x_sec_axis, y_sec_axis}{A secondary axis using \code{ggplot2::sec_axis()} or \code{ggplot2::dup_axis()}.}
 
-\item{x_title}{Axis title string. Use "" for no title.}
+\item{x_title, y_title}{Axis title string. Use \code{""} for no title.}
 
-\item{x_transform}{For a numeric x variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{x_transform, y_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{y_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{y_gridlines}{\code{TRUE} or \code{FALSE} of horizontal \code{y} gridlines. \code{NULL} guesses based on the classes of the \code{x} and \code{y}.}
 
-\item{y_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
-
-\item{y_expand_limits}{For a continuous y variable, any values that the limits should encompass (e.g. 0).}
-
-\item{y_gridlines}{TRUE or FALSE of horizontal y gridlines. NULL guesses based on the classes of the x and y.}
-
-\item{y_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
-
-\item{y_limits}{A vector of length 2 to determine the limits of the axis.}
-
-\item{y_oob}{For a continuous y variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
-
-\item{y_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
-
-\item{y_title}{Axis title string. Use "" for no title.}
-
-\item{y_transform}{For a numeric y variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
-
-\item{col_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{col_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{col_continuous_type}{For a continuous variable, whether to colour as a "gradient" or in "steps". Defaults to "gradient".}
 
 \item{col_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{col_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{col_expand}{Padding to the limits with \code{ggplot2::expansion()}, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{col_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{col_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{col_legend_ncol}{The number of columns for the legend elements.}
+\item{col_legend_ncol, col_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{col_legend_nrow}{The number of rows for the legend elements.}
-
-\item{col_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{col_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{col_limits}{A vector to determine the limits of the scale.}
 
-\item{col_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{col_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{col_pal}{colours to use. A character vector of hex codes (or names).}
 
-\item{col_pal_na}{colour to use for NA values. A character vector of a hex code (or name).}
+\item{col_pal_na}{colour to use for \code{NA} values. A character vector of a hex code (or name).}
 
-\item{col_rescale}{For a continuous variable, a scales::rescale function.}
+\item{col_rescale}{For a continuous variable, a \code{scales::rescale} function.}
 
 \item{col_title}{Legend title string. Use "" for no title.}
 
-\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{alpha_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{alpha_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{alpha_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{alpha_legend_ncol}{The number of columns for the legend elements.}
+\item{alpha_legend_ncol, alpha_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{alpha_legend_nrow}{The number of rows for the legend elements.}
-
-\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{alpha_limits}{A vector to determine the limits of the scale.}
 
-\item{alpha_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{alpha_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{alpha_pal}{Alpha values to use as a numeric vector. For a continuous variable, a range is only needed.}
 
-\item{alpha_pal_na}{Alpha value to use for the NA value.}
+\item{alpha_pal_na}{Alpha value to use for the \code{NA} value.}
 
-\item{alpha_title}{Legend title string. Use "" for no title.}
+\item{alpha_title}{Legend title string. Use \code{""} for no title.}
 
-\item{alpha_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{alpha_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the transform_ prefix (e.g. "log10").}
 
 \item{facet_axes}{Whether to add interior axes and ticks with "margins", "all", "all_x", or "all_y".}
 
 \item{facet_axis_labels}{Whether to add interior axis labels with "margins", "all", "all_x", or "all_y".}
 
-\item{facet_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
+\item{facet_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
 
 \item{facet_labels_position}{When the facet layout is "wrap", the position of the facet labels. Either "top", "right", "bottom" or "left".}
 
 \item{facet_labels_switch}{When the facet layout is "grid", whether to switch the facet labels to the opposite side of the plot. Either "x", "y" or "both".}
 
-\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If NULL and a single facet (or facet2) argument is provided, then defaults to "wrap". If NULL and both facet and facet2 arguments are provided, defaults to "grid".}
+\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If \code{NULL} and a single \code{facet} (or \code{facet2}) argument is provided, then defaults to "wrap". If \code{NULL} and both facet and facet2 arguments are provided, defaults to "grid".}
 
 \item{facet_ncol}{The number of columns of facets. Only applies to a facet layout of "wrap".}
 
@@ -268,15 +246,15 @@ gg_qq(
 
 \item{caption}{Caption title string.}
 
-\item{titles}{A function to format unspecified titles. Defaults to snakecase::to_sentence_case.}
+\item{titles}{A function to format unspecified titles. Defaults to \code{snakecase::to_sentence_case}.}
 
-\item{flipped}{TRUE or FALSE or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
+\item{flipped}{\code{TRUE} or \code{FALSE} or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
 }
 \value{
 A ggplot object.
 }
 \description{
-Create a qq ggplot with a wrapper around ggplot() + geom_qq.
+Create a qq ggplot with a wrapper around \code{ggplot()} + \link[ggplot2:geom_qq]{geom_qq()}.
 }
 \examples{
 

--- a/man/gg_quantile.Rd
+++ b/man/gg_quantile.Rd
@@ -98,161 +98,139 @@ gg_quantile(
 \arguments{
 \item{data}{A data frame or tibble.}
 
-\item{...}{Other arguments passed to within a params list in the layer function.}
+\item{...}{Other arguments passed to within a \code{params} list in \code{layer()}.}
 
 \item{stat}{A statistical transformation to use on the data. A snakecase character string of a ggproto Stat subclass object minus the Stat prefix (e.g. "identity").}
 
-\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a position_* function that outputs a ggproto Position subclass object (e.g. ggplot2::position_identity()).}
+\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a \verb{position_*()} function that outputs a ggproto Position subclass object (e.g. \code{ggplot2::position_identity()}).}
 
-\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. ggplot2::coord_cartesian()).}
+\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. \code{\link[ggplot2:coord_cartesian]{ggplot2::coord_cartesian()}}).}
 
-\item{theme}{A ggplot2 theme (e.g. light_mode_b(), dark_mode_rt() or ggplot2::theme_grey()).}
+\item{theme}{A ggplot2 theme (e.g. \code{\link[=light_mode_b]{light_mode_b()}}, \code{\link[=dark_mode_rt]{dark_mode_rt()}} or \code{\link[ggplot2:ggtheme]{ggplot2::theme_grey()}}).}
 
-\item{x}{Unquoted x aesthetic variable.}
+\item{x}{Unquoted \code{x} aesthetic variable.}
 
-\item{xmin}{Unquoted xmin aesthetic variable.}
+\item{xmin}{Unquoted \code{xmin} aesthetic variable.}
 
-\item{xmax}{Unquoted xmax aesthetic variable.}
+\item{xmax}{Unquoted \code{xmax} aesthetic variable.}
 
-\item{xend}{Unquoted xend aesthetic variable.}
+\item{xend}{Unquoted \code{xend} aesthetic variable.}
 
-\item{y}{Unquoted y aesthetic variable.}
+\item{y}{Unquoted \code{y} aesthetic variable.}
 
-\item{ymin}{Unquoted ymin aesthetic variable.}
+\item{ymin}{Unquoted \code{ymin} aesthetic variable.}
 
-\item{ymax}{Unquoted ymax aesthetic variable.}
+\item{ymax}{Unquoted \code{ymax} aesthetic variable.}
 
-\item{yend}{Unquoted yend aesthetic variable.}
+\item{yend}{Unquoted \code{yend} aesthetic variable.}
 
-\item{z}{Unquoted z aesthetic variable.}
+\item{z}{Unquoted \code{z} aesthetic variable.}
 
-\item{col}{Unquoted col and fill aesthetic variable.}
+\item{col}{Unquoted \code{col} and \code{fill} aesthetic variable.}
 
-\item{alpha}{Unquoted alpha aesthetic variable.}
+\item{alpha}{Unquoted \code{alpha} aesthetic variable.}
 
-\item{facet}{Unquoted facet aesthetic variable.}
+\item{facet}{Unquoted \code{facet} aesthetic variable.}
 
 \item{facet2}{Unquoted second facet variable.}
 
-\item{group}{Unquoted group aesthetic variable.}
+\item{group}{Unquoted \code{group} aesthetic variable.}
 
-\item{subgroup}{Unquoted subgroup aesthetic variable.}
+\item{subgroup}{Unquoted \code{subgroup} aesthetic variable.}
 
-\item{label}{Unquoted label aesthetic variable.}
+\item{label}{Unquoted \code{label} aesthetic variable.}
 
-\item{text}{Unquoted text aesthetic variable.}
+\item{text}{Unquoted \code{text} aesthetic variable.}
 
-\item{sample}{Unquoted sample aesthetic variable.}
+\item{sample}{Unquoted \code{sample} aesthetic variable.}
 
-\item{mapping}{Set of additional aesthetic mappings within the ggplot2::aes function for non-supported aesthetics (e.g. shape, linetype, linewidth, or size) or for delayed evaluation.}
+\item{mapping}{Set of additional aesthetic mappings within \code{ggplot2::aes()} for non-supported aesthetics (e.g. \code{shape}, \code{linetype}, \code{linewidth}, or \code{size}) or for delayed evaluation.}
 
-\item{x_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{x_breaks, y_breaks}{A \verb{scales::breaks_*} function (e.g. \code{\link[scales:breaks_pretty]{scales::breaks_pretty()}}), or a vector of breaks.}
 
-\item{x_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{x_expand, y_expand}{Padding to the limits with the \code{ggplot2::expansion()} function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{x_expand_limits}{For a continuous x variable, any values that the limits should encompass (e.g. 0).}
+\item{x_expand_limits, y_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{x_gridlines}{TRUE or FALSE for vertical x gridlines. NULL guesses based on the classes of the x and y.}
+\item{x_gridlines}{\code{TRUE} or \code{FALSE} for vertical \code{x} gridlines. \code{NULL} guesses based on the classes of the x and y.}
 
-\item{x_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{x_labels, y_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{\link[scales:label_number]{scales::label_comma()}}), or a vector of labels.}
 
-\item{x_limits}{A vector of length 2 to determine the limits of the axis.}
+\item{x_limits, y_limits}{A vector of length 2 to determine the limits of the axis.}
 
-\item{x_oob}{For a continuous x variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{x_oob, y_oob}{For a continuous \code{x} variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
-\item{x_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
+\item{x_sec_axis, y_sec_axis}{A secondary axis using \code{ggplot2::sec_axis()} or \code{ggplot2::dup_axis()}.}
 
-\item{x_title}{Axis title string. Use "" for no title.}
+\item{x_title, y_title}{Axis title string. Use \code{""} for no title.}
 
-\item{x_transform}{For a numeric x variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{x_transform, y_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{y_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{y_gridlines}{\code{TRUE} or \code{FALSE} of horizontal \code{y} gridlines. \code{NULL} guesses based on the classes of the \code{x} and \code{y}.}
 
-\item{y_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
-
-\item{y_expand_limits}{For a continuous y variable, any values that the limits should encompass (e.g. 0).}
-
-\item{y_gridlines}{TRUE or FALSE of horizontal y gridlines. NULL guesses based on the classes of the x and y.}
-
-\item{y_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
-
-\item{y_limits}{A vector of length 2 to determine the limits of the axis.}
-
-\item{y_oob}{For a continuous y variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
-
-\item{y_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
-
-\item{y_title}{Axis title string. Use "" for no title.}
-
-\item{y_transform}{For a numeric y variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
-
-\item{col_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{col_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{col_continuous_type}{For a continuous variable, whether to colour as a "gradient" or in "steps". Defaults to "gradient".}
 
 \item{col_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{col_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{col_expand}{Padding to the limits with \code{ggplot2::expansion()}, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{col_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{col_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{col_legend_ncol}{The number of columns for the legend elements.}
+\item{col_legend_ncol, col_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{col_legend_nrow}{The number of rows for the legend elements.}
-
-\item{col_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{col_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{col_limits}{A vector to determine the limits of the scale.}
 
-\item{col_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{col_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{col_pal}{colours to use. A character vector of hex codes (or names).}
 
-\item{col_pal_na}{colour to use for NA values. A character vector of a hex code (or name).}
+\item{col_pal_na}{colour to use for \code{NA} values. A character vector of a hex code (or name).}
 
-\item{col_rescale}{For a continuous variable, a scales::rescale function.}
+\item{col_rescale}{For a continuous variable, a \code{scales::rescale} function.}
 
 \item{col_title}{Legend title string. Use "" for no title.}
 
-\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{alpha_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{alpha_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{alpha_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{alpha_legend_ncol}{The number of columns for the legend elements.}
+\item{alpha_legend_ncol, alpha_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{alpha_legend_nrow}{The number of rows for the legend elements.}
-
-\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{alpha_limits}{A vector to determine the limits of the scale.}
 
-\item{alpha_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{alpha_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{alpha_pal}{Alpha values to use as a numeric vector. For a continuous variable, a range is only needed.}
 
-\item{alpha_pal_na}{Alpha value to use for the NA value.}
+\item{alpha_pal_na}{Alpha value to use for the \code{NA} value.}
 
-\item{alpha_title}{Legend title string. Use "" for no title.}
+\item{alpha_title}{Legend title string. Use \code{""} for no title.}
 
-\item{alpha_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{alpha_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the transform_ prefix (e.g. "log10").}
 
 \item{facet_axes}{Whether to add interior axes and ticks with "margins", "all", "all_x", or "all_y".}
 
 \item{facet_axis_labels}{Whether to add interior axis labels with "margins", "all", "all_x", or "all_y".}
 
-\item{facet_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
+\item{facet_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
 
 \item{facet_labels_position}{When the facet layout is "wrap", the position of the facet labels. Either "top", "right", "bottom" or "left".}
 
 \item{facet_labels_switch}{When the facet layout is "grid", whether to switch the facet labels to the opposite side of the plot. Either "x", "y" or "both".}
 
-\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If NULL and a single facet (or facet2) argument is provided, then defaults to "wrap". If NULL and both facet and facet2 arguments are provided, defaults to "grid".}
+\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If \code{NULL} and a single \code{facet} (or \code{facet2}) argument is provided, then defaults to "wrap". If \code{NULL} and both facet and facet2 arguments are provided, defaults to "grid".}
 
 \item{facet_ncol}{The number of columns of facets. Only applies to a facet layout of "wrap".}
 
@@ -268,15 +246,15 @@ gg_quantile(
 
 \item{caption}{Caption title string.}
 
-\item{titles}{A function to format unspecified titles. Defaults to snakecase::to_sentence_case.}
+\item{titles}{A function to format unspecified titles. Defaults to \code{snakecase::to_sentence_case}.}
 
-\item{flipped}{TRUE or FALSE or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
+\item{flipped}{\code{TRUE} or \code{FALSE} or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
 }
 \value{
 A ggplot object.
 }
 \description{
-Create an quantile ggplot with a wrapper around ggplot() + geom_quantile.
+Create an quantile ggplot with a wrapper around \code{ggplot()} + \link[ggplot2:geom_quantile]{geom_quantile()}.
 }
 \examples{
 

--- a/man/gg_raster.Rd
+++ b/man/gg_raster.Rd
@@ -98,161 +98,139 @@ gg_raster(
 \arguments{
 \item{data}{A data frame or tibble.}
 
-\item{...}{Other arguments passed to within a params list in the layer function.}
+\item{...}{Other arguments passed to within a \code{params} list in \code{layer()}.}
 
 \item{stat}{A statistical transformation to use on the data. A snakecase character string of a ggproto Stat subclass object minus the Stat prefix (e.g. "identity").}
 
-\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a position_* function that outputs a ggproto Position subclass object (e.g. ggplot2::position_identity()).}
+\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a \verb{position_*()} function that outputs a ggproto Position subclass object (e.g. \code{ggplot2::position_identity()}).}
 
-\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. ggplot2::coord_cartesian()).}
+\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. \code{\link[ggplot2:coord_cartesian]{ggplot2::coord_cartesian()}}).}
 
-\item{theme}{A ggplot2 theme (e.g. light_mode_b(), dark_mode_rt() or ggplot2::theme_grey()).}
+\item{theme}{A ggplot2 theme (e.g. \code{\link[=light_mode_b]{light_mode_b()}}, \code{\link[=dark_mode_rt]{dark_mode_rt()}} or \code{\link[ggplot2:ggtheme]{ggplot2::theme_grey()}}).}
 
-\item{x}{Unquoted x aesthetic variable.}
+\item{x}{Unquoted \code{x} aesthetic variable.}
 
-\item{xmin}{Unquoted xmin aesthetic variable.}
+\item{xmin}{Unquoted \code{xmin} aesthetic variable.}
 
-\item{xmax}{Unquoted xmax aesthetic variable.}
+\item{xmax}{Unquoted \code{xmax} aesthetic variable.}
 
-\item{xend}{Unquoted xend aesthetic variable.}
+\item{xend}{Unquoted \code{xend} aesthetic variable.}
 
-\item{y}{Unquoted y aesthetic variable.}
+\item{y}{Unquoted \code{y} aesthetic variable.}
 
-\item{ymin}{Unquoted ymin aesthetic variable.}
+\item{ymin}{Unquoted \code{ymin} aesthetic variable.}
 
-\item{ymax}{Unquoted ymax aesthetic variable.}
+\item{ymax}{Unquoted \code{ymax} aesthetic variable.}
 
-\item{yend}{Unquoted yend aesthetic variable.}
+\item{yend}{Unquoted \code{yend} aesthetic variable.}
 
-\item{z}{Unquoted z aesthetic variable.}
+\item{z}{Unquoted \code{z} aesthetic variable.}
 
-\item{col}{Unquoted col and fill aesthetic variable.}
+\item{col}{Unquoted \code{col} and \code{fill} aesthetic variable.}
 
-\item{alpha}{Unquoted alpha aesthetic variable.}
+\item{alpha}{Unquoted \code{alpha} aesthetic variable.}
 
-\item{facet}{Unquoted facet aesthetic variable.}
+\item{facet}{Unquoted \code{facet} aesthetic variable.}
 
 \item{facet2}{Unquoted second facet variable.}
 
-\item{group}{Unquoted group aesthetic variable.}
+\item{group}{Unquoted \code{group} aesthetic variable.}
 
-\item{subgroup}{Unquoted subgroup aesthetic variable.}
+\item{subgroup}{Unquoted \code{subgroup} aesthetic variable.}
 
-\item{label}{Unquoted label aesthetic variable.}
+\item{label}{Unquoted \code{label} aesthetic variable.}
 
-\item{text}{Unquoted text aesthetic variable.}
+\item{text}{Unquoted \code{text} aesthetic variable.}
 
-\item{sample}{Unquoted sample aesthetic variable.}
+\item{sample}{Unquoted \code{sample} aesthetic variable.}
 
-\item{mapping}{Set of additional aesthetic mappings within the ggplot2::aes function for non-supported aesthetics (e.g. shape, linetype, linewidth, or size) or for delayed evaluation.}
+\item{mapping}{Set of additional aesthetic mappings within \code{ggplot2::aes()} for non-supported aesthetics (e.g. \code{shape}, \code{linetype}, \code{linewidth}, or \code{size}) or for delayed evaluation.}
 
-\item{x_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{x_breaks, y_breaks}{A \verb{scales::breaks_*} function (e.g. \code{\link[scales:breaks_pretty]{scales::breaks_pretty()}}), or a vector of breaks.}
 
-\item{x_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{x_expand, y_expand}{Padding to the limits with the \code{ggplot2::expansion()} function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{x_expand_limits}{For a continuous x variable, any values that the limits should encompass (e.g. 0).}
+\item{x_expand_limits, y_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{x_gridlines}{TRUE or FALSE for vertical x gridlines. NULL guesses based on the classes of the x and y.}
+\item{x_gridlines}{\code{TRUE} or \code{FALSE} for vertical \code{x} gridlines. \code{NULL} guesses based on the classes of the x and y.}
 
-\item{x_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{x_labels, y_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{\link[scales:label_number]{scales::label_comma()}}), or a vector of labels.}
 
-\item{x_limits}{A vector of length 2 to determine the limits of the axis.}
+\item{x_limits, y_limits}{A vector of length 2 to determine the limits of the axis.}
 
-\item{x_oob}{For a continuous x variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{x_oob, y_oob}{For a continuous \code{x} variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
-\item{x_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
+\item{x_sec_axis, y_sec_axis}{A secondary axis using \code{ggplot2::sec_axis()} or \code{ggplot2::dup_axis()}.}
 
-\item{x_title}{Axis title string. Use "" for no title.}
+\item{x_title, y_title}{Axis title string. Use \code{""} for no title.}
 
-\item{x_transform}{For a numeric x variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{x_transform, y_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{y_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{y_gridlines}{\code{TRUE} or \code{FALSE} of horizontal \code{y} gridlines. \code{NULL} guesses based on the classes of the \code{x} and \code{y}.}
 
-\item{y_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
-
-\item{y_expand_limits}{For a continuous y variable, any values that the limits should encompass (e.g. 0).}
-
-\item{y_gridlines}{TRUE or FALSE of horizontal y gridlines. NULL guesses based on the classes of the x and y.}
-
-\item{y_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
-
-\item{y_limits}{A vector of length 2 to determine the limits of the axis.}
-
-\item{y_oob}{For a continuous y variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
-
-\item{y_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
-
-\item{y_title}{Axis title string. Use "" for no title.}
-
-\item{y_transform}{For a numeric y variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
-
-\item{col_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{col_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{col_continuous_type}{For a continuous variable, whether to colour as a "gradient" or in "steps". Defaults to "gradient".}
 
 \item{col_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{col_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{col_expand}{Padding to the limits with \code{ggplot2::expansion()}, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{col_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{col_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{col_legend_ncol}{The number of columns for the legend elements.}
+\item{col_legend_ncol, col_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{col_legend_nrow}{The number of rows for the legend elements.}
-
-\item{col_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{col_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{col_limits}{A vector to determine the limits of the scale.}
 
-\item{col_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{col_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{col_pal}{colours to use. A character vector of hex codes (or names).}
 
-\item{col_pal_na}{colour to use for NA values. A character vector of a hex code (or name).}
+\item{col_pal_na}{colour to use for \code{NA} values. A character vector of a hex code (or name).}
 
-\item{col_rescale}{For a continuous variable, a scales::rescale function.}
+\item{col_rescale}{For a continuous variable, a \code{scales::rescale} function.}
 
 \item{col_title}{Legend title string. Use "" for no title.}
 
-\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{alpha_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{alpha_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{alpha_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{alpha_legend_ncol}{The number of columns for the legend elements.}
+\item{alpha_legend_ncol, alpha_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{alpha_legend_nrow}{The number of rows for the legend elements.}
-
-\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{alpha_limits}{A vector to determine the limits of the scale.}
 
-\item{alpha_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{alpha_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{alpha_pal}{Alpha values to use as a numeric vector. For a continuous variable, a range is only needed.}
 
-\item{alpha_pal_na}{Alpha value to use for the NA value.}
+\item{alpha_pal_na}{Alpha value to use for the \code{NA} value.}
 
-\item{alpha_title}{Legend title string. Use "" for no title.}
+\item{alpha_title}{Legend title string. Use \code{""} for no title.}
 
-\item{alpha_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{alpha_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the transform_ prefix (e.g. "log10").}
 
 \item{facet_axes}{Whether to add interior axes and ticks with "margins", "all", "all_x", or "all_y".}
 
 \item{facet_axis_labels}{Whether to add interior axis labels with "margins", "all", "all_x", or "all_y".}
 
-\item{facet_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
+\item{facet_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
 
 \item{facet_labels_position}{When the facet layout is "wrap", the position of the facet labels. Either "top", "right", "bottom" or "left".}
 
 \item{facet_labels_switch}{When the facet layout is "grid", whether to switch the facet labels to the opposite side of the plot. Either "x", "y" or "both".}
 
-\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If NULL and a single facet (or facet2) argument is provided, then defaults to "wrap". If NULL and both facet and facet2 arguments are provided, defaults to "grid".}
+\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If \code{NULL} and a single \code{facet} (or \code{facet2}) argument is provided, then defaults to "wrap". If \code{NULL} and both facet and facet2 arguments are provided, defaults to "grid".}
 
 \item{facet_ncol}{The number of columns of facets. Only applies to a facet layout of "wrap".}
 
@@ -268,15 +246,15 @@ gg_raster(
 
 \item{caption}{Caption title string.}
 
-\item{titles}{A function to format unspecified titles. Defaults to snakecase::to_sentence_case.}
+\item{titles}{A function to format unspecified titles. Defaults to \code{snakecase::to_sentence_case}.}
 
-\item{flipped}{TRUE or FALSE or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
+\item{flipped}{\code{TRUE} or \code{FALSE} or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
 }
 \value{
 A ggplot object.
 }
 \description{
-Create a raster ggplot with a wrapper around ggplot() + geom_raster.
+Create a raster ggplot with a wrapper around \code{ggplot()} + \link[ggplot2:geom_tile]{geom_raster()}.
 }
 \examples{
 

--- a/man/gg_rect.Rd
+++ b/man/gg_rect.Rd
@@ -98,161 +98,139 @@ gg_rect(
 \arguments{
 \item{data}{A data frame or tibble.}
 
-\item{...}{Other arguments passed to within a params list in the layer function.}
+\item{...}{Other arguments passed to within a \code{params} list in \code{layer()}.}
 
 \item{stat}{A statistical transformation to use on the data. A snakecase character string of a ggproto Stat subclass object minus the Stat prefix (e.g. "identity").}
 
-\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a position_* function that outputs a ggproto Position subclass object (e.g. ggplot2::position_identity()).}
+\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a \verb{position_*()} function that outputs a ggproto Position subclass object (e.g. \code{ggplot2::position_identity()}).}
 
-\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. ggplot2::coord_cartesian()).}
+\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. \code{\link[ggplot2:coord_cartesian]{ggplot2::coord_cartesian()}}).}
 
-\item{theme}{A ggplot2 theme (e.g. light_mode_b(), dark_mode_rt() or ggplot2::theme_grey()).}
+\item{theme}{A ggplot2 theme (e.g. \code{\link[=light_mode_b]{light_mode_b()}}, \code{\link[=dark_mode_rt]{dark_mode_rt()}} or \code{\link[ggplot2:ggtheme]{ggplot2::theme_grey()}}).}
 
-\item{x}{Unquoted x aesthetic variable.}
+\item{x}{Unquoted \code{x} aesthetic variable.}
 
-\item{xmin}{Unquoted xmin aesthetic variable.}
+\item{xmin}{Unquoted \code{xmin} aesthetic variable.}
 
-\item{xmax}{Unquoted xmax aesthetic variable.}
+\item{xmax}{Unquoted \code{xmax} aesthetic variable.}
 
-\item{xend}{Unquoted xend aesthetic variable.}
+\item{xend}{Unquoted \code{xend} aesthetic variable.}
 
-\item{y}{Unquoted y aesthetic variable.}
+\item{y}{Unquoted \code{y} aesthetic variable.}
 
-\item{ymin}{Unquoted ymin aesthetic variable.}
+\item{ymin}{Unquoted \code{ymin} aesthetic variable.}
 
-\item{ymax}{Unquoted ymax aesthetic variable.}
+\item{ymax}{Unquoted \code{ymax} aesthetic variable.}
 
-\item{yend}{Unquoted yend aesthetic variable.}
+\item{yend}{Unquoted \code{yend} aesthetic variable.}
 
-\item{z}{Unquoted z aesthetic variable.}
+\item{z}{Unquoted \code{z} aesthetic variable.}
 
-\item{col}{Unquoted col and fill aesthetic variable.}
+\item{col}{Unquoted \code{col} and \code{fill} aesthetic variable.}
 
-\item{alpha}{Unquoted alpha aesthetic variable.}
+\item{alpha}{Unquoted \code{alpha} aesthetic variable.}
 
-\item{facet}{Unquoted facet aesthetic variable.}
+\item{facet}{Unquoted \code{facet} aesthetic variable.}
 
 \item{facet2}{Unquoted second facet variable.}
 
-\item{group}{Unquoted group aesthetic variable.}
+\item{group}{Unquoted \code{group} aesthetic variable.}
 
-\item{subgroup}{Unquoted subgroup aesthetic variable.}
+\item{subgroup}{Unquoted \code{subgroup} aesthetic variable.}
 
-\item{label}{Unquoted label aesthetic variable.}
+\item{label}{Unquoted \code{label} aesthetic variable.}
 
-\item{text}{Unquoted text aesthetic variable.}
+\item{text}{Unquoted \code{text} aesthetic variable.}
 
-\item{sample}{Unquoted sample aesthetic variable.}
+\item{sample}{Unquoted \code{sample} aesthetic variable.}
 
-\item{mapping}{Set of additional aesthetic mappings within the ggplot2::aes function for non-supported aesthetics (e.g. shape, linetype, linewidth, or size) or for delayed evaluation.}
+\item{mapping}{Set of additional aesthetic mappings within \code{ggplot2::aes()} for non-supported aesthetics (e.g. \code{shape}, \code{linetype}, \code{linewidth}, or \code{size}) or for delayed evaluation.}
 
-\item{x_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{x_breaks, y_breaks}{A \verb{scales::breaks_*} function (e.g. \code{\link[scales:breaks_pretty]{scales::breaks_pretty()}}), or a vector of breaks.}
 
-\item{x_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{x_expand, y_expand}{Padding to the limits with the \code{ggplot2::expansion()} function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{x_expand_limits}{For a continuous x variable, any values that the limits should encompass (e.g. 0).}
+\item{x_expand_limits, y_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{x_gridlines}{TRUE or FALSE for vertical x gridlines. NULL guesses based on the classes of the x and y.}
+\item{x_gridlines}{\code{TRUE} or \code{FALSE} for vertical \code{x} gridlines. \code{NULL} guesses based on the classes of the x and y.}
 
-\item{x_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{x_labels, y_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{\link[scales:label_number]{scales::label_comma()}}), or a vector of labels.}
 
-\item{x_limits}{A vector of length 2 to determine the limits of the axis.}
+\item{x_limits, y_limits}{A vector of length 2 to determine the limits of the axis.}
 
-\item{x_oob}{For a continuous x variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{x_oob, y_oob}{For a continuous \code{x} variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
-\item{x_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
+\item{x_sec_axis, y_sec_axis}{A secondary axis using \code{ggplot2::sec_axis()} or \code{ggplot2::dup_axis()}.}
 
-\item{x_title}{Axis title string. Use "" for no title.}
+\item{x_title, y_title}{Axis title string. Use \code{""} for no title.}
 
-\item{x_transform}{For a numeric x variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{x_transform, y_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{y_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{y_gridlines}{\code{TRUE} or \code{FALSE} of horizontal \code{y} gridlines. \code{NULL} guesses based on the classes of the \code{x} and \code{y}.}
 
-\item{y_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
-
-\item{y_expand_limits}{For a continuous y variable, any values that the limits should encompass (e.g. 0).}
-
-\item{y_gridlines}{TRUE or FALSE of horizontal y gridlines. NULL guesses based on the classes of the x and y.}
-
-\item{y_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
-
-\item{y_limits}{A vector of length 2 to determine the limits of the axis.}
-
-\item{y_oob}{For a continuous y variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
-
-\item{y_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
-
-\item{y_title}{Axis title string. Use "" for no title.}
-
-\item{y_transform}{For a numeric y variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
-
-\item{col_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{col_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{col_continuous_type}{For a continuous variable, whether to colour as a "gradient" or in "steps". Defaults to "gradient".}
 
 \item{col_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{col_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{col_expand}{Padding to the limits with \code{ggplot2::expansion()}, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{col_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{col_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{col_legend_ncol}{The number of columns for the legend elements.}
+\item{col_legend_ncol, col_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{col_legend_nrow}{The number of rows for the legend elements.}
-
-\item{col_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{col_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{col_limits}{A vector to determine the limits of the scale.}
 
-\item{col_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{col_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{col_pal}{colours to use. A character vector of hex codes (or names).}
 
-\item{col_pal_na}{colour to use for NA values. A character vector of a hex code (or name).}
+\item{col_pal_na}{colour to use for \code{NA} values. A character vector of a hex code (or name).}
 
-\item{col_rescale}{For a continuous variable, a scales::rescale function.}
+\item{col_rescale}{For a continuous variable, a \code{scales::rescale} function.}
 
 \item{col_title}{Legend title string. Use "" for no title.}
 
-\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{alpha_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{alpha_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{alpha_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{alpha_legend_ncol}{The number of columns for the legend elements.}
+\item{alpha_legend_ncol, alpha_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{alpha_legend_nrow}{The number of rows for the legend elements.}
-
-\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{alpha_limits}{A vector to determine the limits of the scale.}
 
-\item{alpha_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{alpha_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{alpha_pal}{Alpha values to use as a numeric vector. For a continuous variable, a range is only needed.}
 
-\item{alpha_pal_na}{Alpha value to use for the NA value.}
+\item{alpha_pal_na}{Alpha value to use for the \code{NA} value.}
 
-\item{alpha_title}{Legend title string. Use "" for no title.}
+\item{alpha_title}{Legend title string. Use \code{""} for no title.}
 
-\item{alpha_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{alpha_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the transform_ prefix (e.g. "log10").}
 
 \item{facet_axes}{Whether to add interior axes and ticks with "margins", "all", "all_x", or "all_y".}
 
 \item{facet_axis_labels}{Whether to add interior axis labels with "margins", "all", "all_x", or "all_y".}
 
-\item{facet_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
+\item{facet_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
 
 \item{facet_labels_position}{When the facet layout is "wrap", the position of the facet labels. Either "top", "right", "bottom" or "left".}
 
 \item{facet_labels_switch}{When the facet layout is "grid", whether to switch the facet labels to the opposite side of the plot. Either "x", "y" or "both".}
 
-\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If NULL and a single facet (or facet2) argument is provided, then defaults to "wrap". If NULL and both facet and facet2 arguments are provided, defaults to "grid".}
+\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If \code{NULL} and a single \code{facet} (or \code{facet2}) argument is provided, then defaults to "wrap". If \code{NULL} and both facet and facet2 arguments are provided, defaults to "grid".}
 
 \item{facet_ncol}{The number of columns of facets. Only applies to a facet layout of "wrap".}
 
@@ -268,15 +246,15 @@ gg_rect(
 
 \item{caption}{Caption title string.}
 
-\item{titles}{A function to format unspecified titles. Defaults to snakecase::to_sentence_case.}
+\item{titles}{A function to format unspecified titles. Defaults to \code{snakecase::to_sentence_case}.}
 
-\item{flipped}{TRUE or FALSE or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
+\item{flipped}{\code{TRUE} or \code{FALSE} or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
 }
 \value{
 A ggplot object.
 }
 \description{
-Create a rect ggplot with a wrapper around ggplot() + geom_rect.
+Create a rect ggplot with a wrapper around \code{ggplot()} + \link[ggplot2:geom_tile]{geom_rect()}.
 }
 \examples{
 

--- a/man/gg_ribbon.Rd
+++ b/man/gg_ribbon.Rd
@@ -98,161 +98,139 @@ gg_ribbon(
 \arguments{
 \item{data}{A data frame or tibble.}
 
-\item{...}{Other arguments passed to within a params list in the layer function.}
+\item{...}{Other arguments passed to within a \code{params} list in \code{layer()}.}
 
 \item{stat}{A statistical transformation to use on the data. A snakecase character string of a ggproto Stat subclass object minus the Stat prefix (e.g. "identity").}
 
-\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a position_* function that outputs a ggproto Position subclass object (e.g. ggplot2::position_identity()).}
+\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a \verb{position_*()} function that outputs a ggproto Position subclass object (e.g. \code{ggplot2::position_identity()}).}
 
-\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. ggplot2::coord_cartesian()).}
+\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. \code{\link[ggplot2:coord_cartesian]{ggplot2::coord_cartesian()}}).}
 
-\item{theme}{A ggplot2 theme (e.g. light_mode_b(), dark_mode_rt() or ggplot2::theme_grey()).}
+\item{theme}{A ggplot2 theme (e.g. \code{\link[=light_mode_b]{light_mode_b()}}, \code{\link[=dark_mode_rt]{dark_mode_rt()}} or \code{\link[ggplot2:ggtheme]{ggplot2::theme_grey()}}).}
 
-\item{x}{Unquoted x aesthetic variable.}
+\item{x}{Unquoted \code{x} aesthetic variable.}
 
-\item{xmin}{Unquoted xmin aesthetic variable.}
+\item{xmin}{Unquoted \code{xmin} aesthetic variable.}
 
-\item{xmax}{Unquoted xmax aesthetic variable.}
+\item{xmax}{Unquoted \code{xmax} aesthetic variable.}
 
-\item{xend}{Unquoted xend aesthetic variable.}
+\item{xend}{Unquoted \code{xend} aesthetic variable.}
 
-\item{y}{Unquoted y aesthetic variable.}
+\item{y}{Unquoted \code{y} aesthetic variable.}
 
-\item{ymin}{Unquoted ymin aesthetic variable.}
+\item{ymin}{Unquoted \code{ymin} aesthetic variable.}
 
-\item{ymax}{Unquoted ymax aesthetic variable.}
+\item{ymax}{Unquoted \code{ymax} aesthetic variable.}
 
-\item{yend}{Unquoted yend aesthetic variable.}
+\item{yend}{Unquoted \code{yend} aesthetic variable.}
 
-\item{z}{Unquoted z aesthetic variable.}
+\item{z}{Unquoted \code{z} aesthetic variable.}
 
-\item{col}{Unquoted col and fill aesthetic variable.}
+\item{col}{Unquoted \code{col} and \code{fill} aesthetic variable.}
 
-\item{alpha}{Unquoted alpha aesthetic variable.}
+\item{alpha}{Unquoted \code{alpha} aesthetic variable.}
 
-\item{facet}{Unquoted facet aesthetic variable.}
+\item{facet}{Unquoted \code{facet} aesthetic variable.}
 
 \item{facet2}{Unquoted second facet variable.}
 
-\item{group}{Unquoted group aesthetic variable.}
+\item{group}{Unquoted \code{group} aesthetic variable.}
 
-\item{subgroup}{Unquoted subgroup aesthetic variable.}
+\item{subgroup}{Unquoted \code{subgroup} aesthetic variable.}
 
-\item{label}{Unquoted label aesthetic variable.}
+\item{label}{Unquoted \code{label} aesthetic variable.}
 
-\item{text}{Unquoted text aesthetic variable.}
+\item{text}{Unquoted \code{text} aesthetic variable.}
 
-\item{sample}{Unquoted sample aesthetic variable.}
+\item{sample}{Unquoted \code{sample} aesthetic variable.}
 
-\item{mapping}{Set of additional aesthetic mappings within the ggplot2::aes function for non-supported aesthetics (e.g. shape, linetype, linewidth, or size) or for delayed evaluation.}
+\item{mapping}{Set of additional aesthetic mappings within \code{ggplot2::aes()} for non-supported aesthetics (e.g. \code{shape}, \code{linetype}, \code{linewidth}, or \code{size}) or for delayed evaluation.}
 
-\item{x_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{x_breaks, y_breaks}{A \verb{scales::breaks_*} function (e.g. \code{\link[scales:breaks_pretty]{scales::breaks_pretty()}}), or a vector of breaks.}
 
-\item{x_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{x_expand, y_expand}{Padding to the limits with the \code{ggplot2::expansion()} function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{x_expand_limits}{For a continuous x variable, any values that the limits should encompass (e.g. 0).}
+\item{x_expand_limits, y_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{x_gridlines}{TRUE or FALSE for vertical x gridlines. NULL guesses based on the classes of the x and y.}
+\item{x_gridlines}{\code{TRUE} or \code{FALSE} for vertical \code{x} gridlines. \code{NULL} guesses based on the classes of the x and y.}
 
-\item{x_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{x_labels, y_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{\link[scales:label_number]{scales::label_comma()}}), or a vector of labels.}
 
-\item{x_limits}{A vector of length 2 to determine the limits of the axis.}
+\item{x_limits, y_limits}{A vector of length 2 to determine the limits of the axis.}
 
-\item{x_oob}{For a continuous x variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{x_oob, y_oob}{For a continuous \code{x} variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
-\item{x_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
+\item{x_sec_axis, y_sec_axis}{A secondary axis using \code{ggplot2::sec_axis()} or \code{ggplot2::dup_axis()}.}
 
-\item{x_title}{Axis title string. Use "" for no title.}
+\item{x_title, y_title}{Axis title string. Use \code{""} for no title.}
 
-\item{x_transform}{For a numeric x variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{x_transform, y_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{y_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{y_gridlines}{\code{TRUE} or \code{FALSE} of horizontal \code{y} gridlines. \code{NULL} guesses based on the classes of the \code{x} and \code{y}.}
 
-\item{y_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
-
-\item{y_expand_limits}{For a continuous y variable, any values that the limits should encompass (e.g. 0).}
-
-\item{y_gridlines}{TRUE or FALSE of horizontal y gridlines. NULL guesses based on the classes of the x and y.}
-
-\item{y_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
-
-\item{y_limits}{A vector of length 2 to determine the limits of the axis.}
-
-\item{y_oob}{For a continuous y variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
-
-\item{y_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
-
-\item{y_title}{Axis title string. Use "" for no title.}
-
-\item{y_transform}{For a numeric y variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
-
-\item{col_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{col_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{col_continuous_type}{For a continuous variable, whether to colour as a "gradient" or in "steps". Defaults to "gradient".}
 
 \item{col_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{col_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{col_expand}{Padding to the limits with \code{ggplot2::expansion()}, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{col_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{col_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{col_legend_ncol}{The number of columns for the legend elements.}
+\item{col_legend_ncol, col_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{col_legend_nrow}{The number of rows for the legend elements.}
-
-\item{col_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{col_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{col_limits}{A vector to determine the limits of the scale.}
 
-\item{col_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{col_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{col_pal}{colours to use. A character vector of hex codes (or names).}
 
-\item{col_pal_na}{colour to use for NA values. A character vector of a hex code (or name).}
+\item{col_pal_na}{colour to use for \code{NA} values. A character vector of a hex code (or name).}
 
-\item{col_rescale}{For a continuous variable, a scales::rescale function.}
+\item{col_rescale}{For a continuous variable, a \code{scales::rescale} function.}
 
 \item{col_title}{Legend title string. Use "" for no title.}
 
-\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{alpha_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{alpha_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{alpha_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{alpha_legend_ncol}{The number of columns for the legend elements.}
+\item{alpha_legend_ncol, alpha_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{alpha_legend_nrow}{The number of rows for the legend elements.}
-
-\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{alpha_limits}{A vector to determine the limits of the scale.}
 
-\item{alpha_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{alpha_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{alpha_pal}{Alpha values to use as a numeric vector. For a continuous variable, a range is only needed.}
 
-\item{alpha_pal_na}{Alpha value to use for the NA value.}
+\item{alpha_pal_na}{Alpha value to use for the \code{NA} value.}
 
-\item{alpha_title}{Legend title string. Use "" for no title.}
+\item{alpha_title}{Legend title string. Use \code{""} for no title.}
 
-\item{alpha_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{alpha_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the transform_ prefix (e.g. "log10").}
 
 \item{facet_axes}{Whether to add interior axes and ticks with "margins", "all", "all_x", or "all_y".}
 
 \item{facet_axis_labels}{Whether to add interior axis labels with "margins", "all", "all_x", or "all_y".}
 
-\item{facet_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
+\item{facet_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
 
 \item{facet_labels_position}{When the facet layout is "wrap", the position of the facet labels. Either "top", "right", "bottom" or "left".}
 
 \item{facet_labels_switch}{When the facet layout is "grid", whether to switch the facet labels to the opposite side of the plot. Either "x", "y" or "both".}
 
-\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If NULL and a single facet (or facet2) argument is provided, then defaults to "wrap". If NULL and both facet and facet2 arguments are provided, defaults to "grid".}
+\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If \code{NULL} and a single \code{facet} (or \code{facet2}) argument is provided, then defaults to "wrap". If \code{NULL} and both facet and facet2 arguments are provided, defaults to "grid".}
 
 \item{facet_ncol}{The number of columns of facets. Only applies to a facet layout of "wrap".}
 
@@ -268,15 +246,15 @@ gg_ribbon(
 
 \item{caption}{Caption title string.}
 
-\item{titles}{A function to format unspecified titles. Defaults to snakecase::to_sentence_case.}
+\item{titles}{A function to format unspecified titles. Defaults to \code{snakecase::to_sentence_case}.}
 
-\item{flipped}{TRUE or FALSE or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
+\item{flipped}{\code{TRUE} or \code{FALSE} or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
 }
 \value{
 A ggplot object.
 }
 \description{
-Create a ribbon ggplot with a wrapper around ggplot() + geom_ribbon.
+Create a ribbon ggplot with a wrapper around \code{ggplot()} + \link[ggplot2:geom_ribbon]{geom_ribbon()}
 }
 \examples{
 

--- a/man/gg_rug.Rd
+++ b/man/gg_rug.Rd
@@ -98,161 +98,139 @@ gg_rug(
 \arguments{
 \item{data}{A data frame or tibble.}
 
-\item{...}{Other arguments passed to within a params list in the layer function.}
+\item{...}{Other arguments passed to within a \code{params} list in \code{layer()}.}
 
 \item{stat}{A statistical transformation to use on the data. A snakecase character string of a ggproto Stat subclass object minus the Stat prefix (e.g. "identity").}
 
-\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a position_* function that outputs a ggproto Position subclass object (e.g. ggplot2::position_identity()).}
+\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a \verb{position_*()} function that outputs a ggproto Position subclass object (e.g. \code{ggplot2::position_identity()}).}
 
-\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. ggplot2::coord_cartesian()).}
+\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. \code{\link[ggplot2:coord_cartesian]{ggplot2::coord_cartesian()}}).}
 
-\item{theme}{A ggplot2 theme (e.g. light_mode_b(), dark_mode_rt() or ggplot2::theme_grey()).}
+\item{theme}{A ggplot2 theme (e.g. \code{\link[=light_mode_b]{light_mode_b()}}, \code{\link[=dark_mode_rt]{dark_mode_rt()}} or \code{\link[ggplot2:ggtheme]{ggplot2::theme_grey()}}).}
 
-\item{x}{Unquoted x aesthetic variable.}
+\item{x}{Unquoted \code{x} aesthetic variable.}
 
-\item{xmin}{Unquoted xmin aesthetic variable.}
+\item{xmin}{Unquoted \code{xmin} aesthetic variable.}
 
-\item{xmax}{Unquoted xmax aesthetic variable.}
+\item{xmax}{Unquoted \code{xmax} aesthetic variable.}
 
-\item{xend}{Unquoted xend aesthetic variable.}
+\item{xend}{Unquoted \code{xend} aesthetic variable.}
 
-\item{y}{Unquoted y aesthetic variable.}
+\item{y}{Unquoted \code{y} aesthetic variable.}
 
-\item{ymin}{Unquoted ymin aesthetic variable.}
+\item{ymin}{Unquoted \code{ymin} aesthetic variable.}
 
-\item{ymax}{Unquoted ymax aesthetic variable.}
+\item{ymax}{Unquoted \code{ymax} aesthetic variable.}
 
-\item{yend}{Unquoted yend aesthetic variable.}
+\item{yend}{Unquoted \code{yend} aesthetic variable.}
 
-\item{z}{Unquoted z aesthetic variable.}
+\item{z}{Unquoted \code{z} aesthetic variable.}
 
-\item{col}{Unquoted col and fill aesthetic variable.}
+\item{col}{Unquoted \code{col} and \code{fill} aesthetic variable.}
 
-\item{alpha}{Unquoted alpha aesthetic variable.}
+\item{alpha}{Unquoted \code{alpha} aesthetic variable.}
 
-\item{facet}{Unquoted facet aesthetic variable.}
+\item{facet}{Unquoted \code{facet} aesthetic variable.}
 
 \item{facet2}{Unquoted second facet variable.}
 
-\item{group}{Unquoted group aesthetic variable.}
+\item{group}{Unquoted \code{group} aesthetic variable.}
 
-\item{subgroup}{Unquoted subgroup aesthetic variable.}
+\item{subgroup}{Unquoted \code{subgroup} aesthetic variable.}
 
-\item{label}{Unquoted label aesthetic variable.}
+\item{label}{Unquoted \code{label} aesthetic variable.}
 
-\item{text}{Unquoted text aesthetic variable.}
+\item{text}{Unquoted \code{text} aesthetic variable.}
 
-\item{sample}{Unquoted sample aesthetic variable.}
+\item{sample}{Unquoted \code{sample} aesthetic variable.}
 
-\item{mapping}{Set of additional aesthetic mappings within the ggplot2::aes function for non-supported aesthetics (e.g. shape, linetype, linewidth, or size) or for delayed evaluation.}
+\item{mapping}{Set of additional aesthetic mappings within \code{ggplot2::aes()} for non-supported aesthetics (e.g. \code{shape}, \code{linetype}, \code{linewidth}, or \code{size}) or for delayed evaluation.}
 
-\item{x_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{x_breaks, y_breaks}{A \verb{scales::breaks_*} function (e.g. \code{\link[scales:breaks_pretty]{scales::breaks_pretty()}}), or a vector of breaks.}
 
-\item{x_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{x_expand, y_expand}{Padding to the limits with the \code{ggplot2::expansion()} function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{x_expand_limits}{For a continuous x variable, any values that the limits should encompass (e.g. 0).}
+\item{x_expand_limits, y_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{x_gridlines}{TRUE or FALSE for vertical x gridlines. NULL guesses based on the classes of the x and y.}
+\item{x_gridlines}{\code{TRUE} or \code{FALSE} for vertical \code{x} gridlines. \code{NULL} guesses based on the classes of the x and y.}
 
-\item{x_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{x_labels, y_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{\link[scales:label_number]{scales::label_comma()}}), or a vector of labels.}
 
-\item{x_limits}{A vector of length 2 to determine the limits of the axis.}
+\item{x_limits, y_limits}{A vector of length 2 to determine the limits of the axis.}
 
-\item{x_oob}{For a continuous x variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{x_oob, y_oob}{For a continuous \code{x} variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
-\item{x_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
+\item{x_sec_axis, y_sec_axis}{A secondary axis using \code{ggplot2::sec_axis()} or \code{ggplot2::dup_axis()}.}
 
-\item{x_title}{Axis title string. Use "" for no title.}
+\item{x_title, y_title}{Axis title string. Use \code{""} for no title.}
 
-\item{x_transform}{For a numeric x variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{x_transform, y_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{y_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{y_gridlines}{\code{TRUE} or \code{FALSE} of horizontal \code{y} gridlines. \code{NULL} guesses based on the classes of the \code{x} and \code{y}.}
 
-\item{y_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
-
-\item{y_expand_limits}{For a continuous y variable, any values that the limits should encompass (e.g. 0).}
-
-\item{y_gridlines}{TRUE or FALSE of horizontal y gridlines. NULL guesses based on the classes of the x and y.}
-
-\item{y_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
-
-\item{y_limits}{A vector of length 2 to determine the limits of the axis.}
-
-\item{y_oob}{For a continuous y variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
-
-\item{y_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
-
-\item{y_title}{Axis title string. Use "" for no title.}
-
-\item{y_transform}{For a numeric y variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
-
-\item{col_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{col_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{col_continuous_type}{For a continuous variable, whether to colour as a "gradient" or in "steps". Defaults to "gradient".}
 
 \item{col_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{col_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{col_expand}{Padding to the limits with \code{ggplot2::expansion()}, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{col_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{col_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{col_legend_ncol}{The number of columns for the legend elements.}
+\item{col_legend_ncol, col_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{col_legend_nrow}{The number of rows for the legend elements.}
-
-\item{col_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{col_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{col_limits}{A vector to determine the limits of the scale.}
 
-\item{col_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{col_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{col_pal}{colours to use. A character vector of hex codes (or names).}
 
-\item{col_pal_na}{colour to use for NA values. A character vector of a hex code (or name).}
+\item{col_pal_na}{colour to use for \code{NA} values. A character vector of a hex code (or name).}
 
-\item{col_rescale}{For a continuous variable, a scales::rescale function.}
+\item{col_rescale}{For a continuous variable, a \code{scales::rescale} function.}
 
 \item{col_title}{Legend title string. Use "" for no title.}
 
-\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{alpha_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{alpha_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{alpha_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{alpha_legend_ncol}{The number of columns for the legend elements.}
+\item{alpha_legend_ncol, alpha_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{alpha_legend_nrow}{The number of rows for the legend elements.}
-
-\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{alpha_limits}{A vector to determine the limits of the scale.}
 
-\item{alpha_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{alpha_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{alpha_pal}{Alpha values to use as a numeric vector. For a continuous variable, a range is only needed.}
 
-\item{alpha_pal_na}{Alpha value to use for the NA value.}
+\item{alpha_pal_na}{Alpha value to use for the \code{NA} value.}
 
-\item{alpha_title}{Legend title string. Use "" for no title.}
+\item{alpha_title}{Legend title string. Use \code{""} for no title.}
 
-\item{alpha_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{alpha_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the transform_ prefix (e.g. "log10").}
 
 \item{facet_axes}{Whether to add interior axes and ticks with "margins", "all", "all_x", or "all_y".}
 
 \item{facet_axis_labels}{Whether to add interior axis labels with "margins", "all", "all_x", or "all_y".}
 
-\item{facet_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
+\item{facet_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
 
 \item{facet_labels_position}{When the facet layout is "wrap", the position of the facet labels. Either "top", "right", "bottom" or "left".}
 
 \item{facet_labels_switch}{When the facet layout is "grid", whether to switch the facet labels to the opposite side of the plot. Either "x", "y" or "both".}
 
-\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If NULL and a single facet (or facet2) argument is provided, then defaults to "wrap". If NULL and both facet and facet2 arguments are provided, defaults to "grid".}
+\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If \code{NULL} and a single \code{facet} (or \code{facet2}) argument is provided, then defaults to "wrap". If \code{NULL} and both facet and facet2 arguments are provided, defaults to "grid".}
 
 \item{facet_ncol}{The number of columns of facets. Only applies to a facet layout of "wrap".}
 
@@ -268,15 +246,15 @@ gg_rug(
 
 \item{caption}{Caption title string.}
 
-\item{titles}{A function to format unspecified titles. Defaults to snakecase::to_sentence_case.}
+\item{titles}{A function to format unspecified titles. Defaults to \code{snakecase::to_sentence_case}.}
 
-\item{flipped}{TRUE or FALSE or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
+\item{flipped}{\code{TRUE} or \code{FALSE} or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
 }
 \value{
 A ggplot object.
 }
 \description{
-Create a rug ggplot with a wrapper around ggplot() + geom_rug.
+Create a rug ggplot with a wrapper around \code{ggplot()} + \link[ggplot2:geom_rug]{geom_rug()}.
 }
 \examples{
 

--- a/man/gg_segment.Rd
+++ b/man/gg_segment.Rd
@@ -98,161 +98,139 @@ gg_segment(
 \arguments{
 \item{data}{A data frame or tibble.}
 
-\item{...}{Other arguments passed to within a params list in the layer function.}
+\item{...}{Other arguments passed to within a \code{params} list in \code{layer()}.}
 
 \item{stat}{A statistical transformation to use on the data. A snakecase character string of a ggproto Stat subclass object minus the Stat prefix (e.g. "identity").}
 
-\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a position_* function that outputs a ggproto Position subclass object (e.g. ggplot2::position_identity()).}
+\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a \verb{position_*()} function that outputs a ggproto Position subclass object (e.g. \code{ggplot2::position_identity()}).}
 
-\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. ggplot2::coord_cartesian()).}
+\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. \code{\link[ggplot2:coord_cartesian]{ggplot2::coord_cartesian()}}).}
 
-\item{theme}{A ggplot2 theme (e.g. light_mode_b(), dark_mode_rt() or ggplot2::theme_grey()).}
+\item{theme}{A ggplot2 theme (e.g. \code{\link[=light_mode_b]{light_mode_b()}}, \code{\link[=dark_mode_rt]{dark_mode_rt()}} or \code{\link[ggplot2:ggtheme]{ggplot2::theme_grey()}}).}
 
-\item{x}{Unquoted x aesthetic variable.}
+\item{x}{Unquoted \code{x} aesthetic variable.}
 
-\item{xmin}{Unquoted xmin aesthetic variable.}
+\item{xmin}{Unquoted \code{xmin} aesthetic variable.}
 
-\item{xmax}{Unquoted xmax aesthetic variable.}
+\item{xmax}{Unquoted \code{xmax} aesthetic variable.}
 
-\item{xend}{Unquoted xend aesthetic variable.}
+\item{xend}{Unquoted \code{xend} aesthetic variable.}
 
-\item{y}{Unquoted y aesthetic variable.}
+\item{y}{Unquoted \code{y} aesthetic variable.}
 
-\item{ymin}{Unquoted ymin aesthetic variable.}
+\item{ymin}{Unquoted \code{ymin} aesthetic variable.}
 
-\item{ymax}{Unquoted ymax aesthetic variable.}
+\item{ymax}{Unquoted \code{ymax} aesthetic variable.}
 
-\item{yend}{Unquoted yend aesthetic variable.}
+\item{yend}{Unquoted \code{yend} aesthetic variable.}
 
-\item{z}{Unquoted z aesthetic variable.}
+\item{z}{Unquoted \code{z} aesthetic variable.}
 
-\item{col}{Unquoted col and fill aesthetic variable.}
+\item{col}{Unquoted \code{col} and \code{fill} aesthetic variable.}
 
-\item{alpha}{Unquoted alpha aesthetic variable.}
+\item{alpha}{Unquoted \code{alpha} aesthetic variable.}
 
-\item{facet}{Unquoted facet aesthetic variable.}
+\item{facet}{Unquoted \code{facet} aesthetic variable.}
 
 \item{facet2}{Unquoted second facet variable.}
 
-\item{group}{Unquoted group aesthetic variable.}
+\item{group}{Unquoted \code{group} aesthetic variable.}
 
-\item{subgroup}{Unquoted subgroup aesthetic variable.}
+\item{subgroup}{Unquoted \code{subgroup} aesthetic variable.}
 
-\item{label}{Unquoted label aesthetic variable.}
+\item{label}{Unquoted \code{label} aesthetic variable.}
 
-\item{text}{Unquoted text aesthetic variable.}
+\item{text}{Unquoted \code{text} aesthetic variable.}
 
-\item{sample}{Unquoted sample aesthetic variable.}
+\item{sample}{Unquoted \code{sample} aesthetic variable.}
 
-\item{mapping}{Set of additional aesthetic mappings within the ggplot2::aes function for non-supported aesthetics (e.g. shape, linetype, linewidth, or size) or for delayed evaluation.}
+\item{mapping}{Set of additional aesthetic mappings within \code{ggplot2::aes()} for non-supported aesthetics (e.g. \code{shape}, \code{linetype}, \code{linewidth}, or \code{size}) or for delayed evaluation.}
 
-\item{x_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{x_breaks, y_breaks}{A \verb{scales::breaks_*} function (e.g. \code{\link[scales:breaks_pretty]{scales::breaks_pretty()}}), or a vector of breaks.}
 
-\item{x_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{x_expand, y_expand}{Padding to the limits with the \code{ggplot2::expansion()} function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{x_expand_limits}{For a continuous x variable, any values that the limits should encompass (e.g. 0).}
+\item{x_expand_limits, y_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{x_gridlines}{TRUE or FALSE for vertical x gridlines. NULL guesses based on the classes of the x and y.}
+\item{x_gridlines}{\code{TRUE} or \code{FALSE} for vertical \code{x} gridlines. \code{NULL} guesses based on the classes of the x and y.}
 
-\item{x_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{x_labels, y_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{\link[scales:label_number]{scales::label_comma()}}), or a vector of labels.}
 
-\item{x_limits}{A vector of length 2 to determine the limits of the axis.}
+\item{x_limits, y_limits}{A vector of length 2 to determine the limits of the axis.}
 
-\item{x_oob}{For a continuous x variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{x_oob, y_oob}{For a continuous \code{x} variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
-\item{x_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
+\item{x_sec_axis, y_sec_axis}{A secondary axis using \code{ggplot2::sec_axis()} or \code{ggplot2::dup_axis()}.}
 
-\item{x_title}{Axis title string. Use "" for no title.}
+\item{x_title, y_title}{Axis title string. Use \code{""} for no title.}
 
-\item{x_transform}{For a numeric x variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{x_transform, y_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{y_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{y_gridlines}{\code{TRUE} or \code{FALSE} of horizontal \code{y} gridlines. \code{NULL} guesses based on the classes of the \code{x} and \code{y}.}
 
-\item{y_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
-
-\item{y_expand_limits}{For a continuous y variable, any values that the limits should encompass (e.g. 0).}
-
-\item{y_gridlines}{TRUE or FALSE of horizontal y gridlines. NULL guesses based on the classes of the x and y.}
-
-\item{y_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
-
-\item{y_limits}{A vector of length 2 to determine the limits of the axis.}
-
-\item{y_oob}{For a continuous y variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
-
-\item{y_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
-
-\item{y_title}{Axis title string. Use "" for no title.}
-
-\item{y_transform}{For a numeric y variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
-
-\item{col_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{col_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{col_continuous_type}{For a continuous variable, whether to colour as a "gradient" or in "steps". Defaults to "gradient".}
 
 \item{col_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{col_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{col_expand}{Padding to the limits with \code{ggplot2::expansion()}, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{col_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{col_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{col_legend_ncol}{The number of columns for the legend elements.}
+\item{col_legend_ncol, col_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{col_legend_nrow}{The number of rows for the legend elements.}
-
-\item{col_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{col_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{col_limits}{A vector to determine the limits of the scale.}
 
-\item{col_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{col_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{col_pal}{colours to use. A character vector of hex codes (or names).}
 
-\item{col_pal_na}{colour to use for NA values. A character vector of a hex code (or name).}
+\item{col_pal_na}{colour to use for \code{NA} values. A character vector of a hex code (or name).}
 
-\item{col_rescale}{For a continuous variable, a scales::rescale function.}
+\item{col_rescale}{For a continuous variable, a \code{scales::rescale} function.}
 
 \item{col_title}{Legend title string. Use "" for no title.}
 
-\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{alpha_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{alpha_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{alpha_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{alpha_legend_ncol}{The number of columns for the legend elements.}
+\item{alpha_legend_ncol, alpha_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{alpha_legend_nrow}{The number of rows for the legend elements.}
-
-\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{alpha_limits}{A vector to determine the limits of the scale.}
 
-\item{alpha_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{alpha_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{alpha_pal}{Alpha values to use as a numeric vector. For a continuous variable, a range is only needed.}
 
-\item{alpha_pal_na}{Alpha value to use for the NA value.}
+\item{alpha_pal_na}{Alpha value to use for the \code{NA} value.}
 
-\item{alpha_title}{Legend title string. Use "" for no title.}
+\item{alpha_title}{Legend title string. Use \code{""} for no title.}
 
-\item{alpha_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{alpha_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the transform_ prefix (e.g. "log10").}
 
 \item{facet_axes}{Whether to add interior axes and ticks with "margins", "all", "all_x", or "all_y".}
 
 \item{facet_axis_labels}{Whether to add interior axis labels with "margins", "all", "all_x", or "all_y".}
 
-\item{facet_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
+\item{facet_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
 
 \item{facet_labels_position}{When the facet layout is "wrap", the position of the facet labels. Either "top", "right", "bottom" or "left".}
 
 \item{facet_labels_switch}{When the facet layout is "grid", whether to switch the facet labels to the opposite side of the plot. Either "x", "y" or "both".}
 
-\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If NULL and a single facet (or facet2) argument is provided, then defaults to "wrap". If NULL and both facet and facet2 arguments are provided, defaults to "grid".}
+\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If \code{NULL} and a single \code{facet} (or \code{facet2}) argument is provided, then defaults to "wrap". If \code{NULL} and both facet and facet2 arguments are provided, defaults to "grid".}
 
 \item{facet_ncol}{The number of columns of facets. Only applies to a facet layout of "wrap".}
 
@@ -268,15 +246,15 @@ gg_segment(
 
 \item{caption}{Caption title string.}
 
-\item{titles}{A function to format unspecified titles. Defaults to snakecase::to_sentence_case.}
+\item{titles}{A function to format unspecified titles. Defaults to \code{snakecase::to_sentence_case}.}
 
-\item{flipped}{TRUE or FALSE or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
+\item{flipped}{\code{TRUE} or \code{FALSE} or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
 }
 \value{
 A ggplot object.
 }
 \description{
-Create a segment ggplot with a wrapper around ggplot() + geom_segment.
+Create a segment ggplot with a wrapper around \code{ggplot()} + \link[ggplot2:geom_segment]{geom_segment()}.
 }
 \examples{
 

--- a/man/gg_sf.Rd
+++ b/man/gg_sf.Rd
@@ -98,161 +98,139 @@ gg_sf(
 \arguments{
 \item{data}{A data frame or tibble.}
 
-\item{...}{Other arguments passed to within a params list in the layer function.}
+\item{...}{Other arguments passed to within a \code{params} list in \code{layer()}.}
 
 \item{stat}{A statistical transformation to use on the data. A snakecase character string of a ggproto Stat subclass object minus the Stat prefix (e.g. "identity").}
 
-\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a position_* function that outputs a ggproto Position subclass object (e.g. ggplot2::position_identity()).}
+\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a \verb{position_*()} function that outputs a ggproto Position subclass object (e.g. \code{ggplot2::position_identity()}).}
 
-\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. ggplot2::coord_cartesian()).}
+\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. \code{\link[ggplot2:coord_cartesian]{ggplot2::coord_cartesian()}}).}
 
-\item{theme}{A ggplot2 theme (e.g. light_mode_b(), dark_mode_rt() or ggplot2::theme_grey()).}
+\item{theme}{A ggplot2 theme (e.g. \code{\link[=light_mode_b]{light_mode_b()}}, \code{\link[=dark_mode_rt]{dark_mode_rt()}} or \code{\link[ggplot2:ggtheme]{ggplot2::theme_grey()}}).}
 
-\item{x}{Unquoted x aesthetic variable.}
+\item{x}{Unquoted \code{x} aesthetic variable.}
 
-\item{xmin}{Unquoted xmin aesthetic variable.}
+\item{xmin}{Unquoted \code{xmin} aesthetic variable.}
 
-\item{xmax}{Unquoted xmax aesthetic variable.}
+\item{xmax}{Unquoted \code{xmax} aesthetic variable.}
 
-\item{xend}{Unquoted xend aesthetic variable.}
+\item{xend}{Unquoted \code{xend} aesthetic variable.}
 
-\item{y}{Unquoted y aesthetic variable.}
+\item{y}{Unquoted \code{y} aesthetic variable.}
 
-\item{ymin}{Unquoted ymin aesthetic variable.}
+\item{ymin}{Unquoted \code{ymin} aesthetic variable.}
 
-\item{ymax}{Unquoted ymax aesthetic variable.}
+\item{ymax}{Unquoted \code{ymax} aesthetic variable.}
 
-\item{yend}{Unquoted yend aesthetic variable.}
+\item{yend}{Unquoted \code{yend} aesthetic variable.}
 
-\item{z}{Unquoted z aesthetic variable.}
+\item{z}{Unquoted \code{z} aesthetic variable.}
 
-\item{col}{Unquoted col and fill aesthetic variable.}
+\item{col}{Unquoted \code{col} and \code{fill} aesthetic variable.}
 
-\item{alpha}{Unquoted alpha aesthetic variable.}
+\item{alpha}{Unquoted \code{alpha} aesthetic variable.}
 
-\item{facet}{Unquoted facet aesthetic variable.}
+\item{facet}{Unquoted \code{facet} aesthetic variable.}
 
 \item{facet2}{Unquoted second facet variable.}
 
-\item{group}{Unquoted group aesthetic variable.}
+\item{group}{Unquoted \code{group} aesthetic variable.}
 
-\item{subgroup}{Unquoted subgroup aesthetic variable.}
+\item{subgroup}{Unquoted \code{subgroup} aesthetic variable.}
 
-\item{label}{Unquoted label aesthetic variable.}
+\item{label}{Unquoted \code{label} aesthetic variable.}
 
-\item{text}{Unquoted text aesthetic variable.}
+\item{text}{Unquoted \code{text} aesthetic variable.}
 
-\item{sample}{Unquoted sample aesthetic variable.}
+\item{sample}{Unquoted \code{sample} aesthetic variable.}
 
-\item{mapping}{Set of additional aesthetic mappings within the ggplot2::aes function for non-supported aesthetics (e.g. shape, linetype, linewidth, or size) or for delayed evaluation.}
+\item{mapping}{Set of additional aesthetic mappings within \code{ggplot2::aes()} for non-supported aesthetics (e.g. \code{shape}, \code{linetype}, \code{linewidth}, or \code{size}) or for delayed evaluation.}
 
-\item{x_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{x_breaks, y_breaks}{A \verb{scales::breaks_*} function (e.g. \code{\link[scales:breaks_pretty]{scales::breaks_pretty()}}), or a vector of breaks.}
 
-\item{x_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{x_expand, y_expand}{Padding to the limits with the \code{ggplot2::expansion()} function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{x_expand_limits}{For a continuous x variable, any values that the limits should encompass (e.g. 0).}
+\item{x_expand_limits, y_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{x_gridlines}{TRUE or FALSE for vertical x gridlines. NULL guesses based on the classes of the x and y.}
+\item{x_gridlines}{\code{TRUE} or \code{FALSE} for vertical \code{x} gridlines. \code{NULL} guesses based on the classes of the x and y.}
 
-\item{x_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{x_labels, y_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{\link[scales:label_number]{scales::label_comma()}}), or a vector of labels.}
 
-\item{x_limits}{A vector of length 2 to determine the limits of the axis.}
+\item{x_limits, y_limits}{A vector of length 2 to determine the limits of the axis.}
 
-\item{x_oob}{For a continuous x variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{x_oob, y_oob}{For a continuous \code{x} variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
-\item{x_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
+\item{x_sec_axis, y_sec_axis}{A secondary axis using \code{ggplot2::sec_axis()} or \code{ggplot2::dup_axis()}.}
 
-\item{x_title}{Axis title string. Use "" for no title.}
+\item{x_title, y_title}{Axis title string. Use \code{""} for no title.}
 
-\item{x_transform}{For a numeric x variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{x_transform, y_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{y_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{y_gridlines}{\code{TRUE} or \code{FALSE} of horizontal \code{y} gridlines. \code{NULL} guesses based on the classes of the \code{x} and \code{y}.}
 
-\item{y_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
-
-\item{y_expand_limits}{For a continuous y variable, any values that the limits should encompass (e.g. 0).}
-
-\item{y_gridlines}{TRUE or FALSE of horizontal y gridlines. NULL guesses based on the classes of the x and y.}
-
-\item{y_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
-
-\item{y_limits}{A vector of length 2 to determine the limits of the axis.}
-
-\item{y_oob}{For a continuous y variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
-
-\item{y_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
-
-\item{y_title}{Axis title string. Use "" for no title.}
-
-\item{y_transform}{For a numeric y variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
-
-\item{col_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{col_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{col_continuous_type}{For a continuous variable, whether to colour as a "gradient" or in "steps". Defaults to "gradient".}
 
 \item{col_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{col_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{col_expand}{Padding to the limits with \code{ggplot2::expansion()}, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{col_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{col_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{col_legend_ncol}{The number of columns for the legend elements.}
+\item{col_legend_ncol, col_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{col_legend_nrow}{The number of rows for the legend elements.}
-
-\item{col_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{col_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{col_limits}{A vector to determine the limits of the scale.}
 
-\item{col_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{col_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{col_pal}{colours to use. A character vector of hex codes (or names).}
 
-\item{col_pal_na}{colour to use for NA values. A character vector of a hex code (or name).}
+\item{col_pal_na}{colour to use for \code{NA} values. A character vector of a hex code (or name).}
 
-\item{col_rescale}{For a continuous variable, a scales::rescale function.}
+\item{col_rescale}{For a continuous variable, a \code{scales::rescale} function.}
 
 \item{col_title}{Legend title string. Use "" for no title.}
 
-\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{alpha_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{alpha_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{alpha_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{alpha_legend_ncol}{The number of columns for the legend elements.}
+\item{alpha_legend_ncol, alpha_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{alpha_legend_nrow}{The number of rows for the legend elements.}
-
-\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{alpha_limits}{A vector to determine the limits of the scale.}
 
-\item{alpha_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{alpha_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{alpha_pal}{Alpha values to use as a numeric vector. For a continuous variable, a range is only needed.}
 
-\item{alpha_pal_na}{Alpha value to use for the NA value.}
+\item{alpha_pal_na}{Alpha value to use for the \code{NA} value.}
 
-\item{alpha_title}{Legend title string. Use "" for no title.}
+\item{alpha_title}{Legend title string. Use \code{""} for no title.}
 
-\item{alpha_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{alpha_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the transform_ prefix (e.g. "log10").}
 
 \item{facet_axes}{Whether to add interior axes and ticks with "margins", "all", "all_x", or "all_y".}
 
 \item{facet_axis_labels}{Whether to add interior axis labels with "margins", "all", "all_x", or "all_y".}
 
-\item{facet_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
+\item{facet_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
 
 \item{facet_labels_position}{When the facet layout is "wrap", the position of the facet labels. Either "top", "right", "bottom" or "left".}
 
 \item{facet_labels_switch}{When the facet layout is "grid", whether to switch the facet labels to the opposite side of the plot. Either "x", "y" or "both".}
 
-\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If NULL and a single facet (or facet2) argument is provided, then defaults to "wrap". If NULL and both facet and facet2 arguments are provided, defaults to "grid".}
+\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If \code{NULL} and a single \code{facet} (or \code{facet2}) argument is provided, then defaults to "wrap". If \code{NULL} and both facet and facet2 arguments are provided, defaults to "grid".}
 
 \item{facet_ncol}{The number of columns of facets. Only applies to a facet layout of "wrap".}
 
@@ -268,15 +246,15 @@ gg_sf(
 
 \item{caption}{Caption title string.}
 
-\item{titles}{A function to format unspecified titles. Defaults to snakecase::to_sentence_case.}
+\item{titles}{A function to format unspecified titles. Defaults to \code{snakecase::to_sentence_case}.}
 
-\item{flipped}{TRUE or FALSE or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
+\item{flipped}{\code{TRUE} or \code{FALSE} or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
 }
 \value{
 A ggplot object.
 }
 \description{
-Create a blank ggplot with a wrapper around ggplot() + geom_sf.
+Create a blank ggplot with a wrapper around \code{ggplot()} + \link[ggplot2:ggsf]{geom_sf()}.
 }
 \examples{
 

--- a/man/gg_smooth.Rd
+++ b/man/gg_smooth.Rd
@@ -98,161 +98,139 @@ gg_smooth(
 \arguments{
 \item{data}{A data frame or tibble.}
 
-\item{...}{Other arguments passed to within a params list in the layer function.}
+\item{...}{Other arguments passed to within a \code{params} list in \code{layer()}.}
 
 \item{stat}{A statistical transformation to use on the data. A snakecase character string of a ggproto Stat subclass object minus the Stat prefix (e.g. "identity").}
 
-\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a position_* function that outputs a ggproto Position subclass object (e.g. ggplot2::position_identity()).}
+\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a \verb{position_*()} function that outputs a ggproto Position subclass object (e.g. \code{ggplot2::position_identity()}).}
 
-\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. ggplot2::coord_cartesian()).}
+\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. \code{\link[ggplot2:coord_cartesian]{ggplot2::coord_cartesian()}}).}
 
-\item{theme}{A ggplot2 theme (e.g. light_mode_b(), dark_mode_rt() or ggplot2::theme_grey()).}
+\item{theme}{A ggplot2 theme (e.g. \code{\link[=light_mode_b]{light_mode_b()}}, \code{\link[=dark_mode_rt]{dark_mode_rt()}} or \code{\link[ggplot2:ggtheme]{ggplot2::theme_grey()}}).}
 
-\item{x}{Unquoted x aesthetic variable.}
+\item{x}{Unquoted \code{x} aesthetic variable.}
 
-\item{xmin}{Unquoted xmin aesthetic variable.}
+\item{xmin}{Unquoted \code{xmin} aesthetic variable.}
 
-\item{xmax}{Unquoted xmax aesthetic variable.}
+\item{xmax}{Unquoted \code{xmax} aesthetic variable.}
 
-\item{xend}{Unquoted xend aesthetic variable.}
+\item{xend}{Unquoted \code{xend} aesthetic variable.}
 
-\item{y}{Unquoted y aesthetic variable.}
+\item{y}{Unquoted \code{y} aesthetic variable.}
 
-\item{ymin}{Unquoted ymin aesthetic variable.}
+\item{ymin}{Unquoted \code{ymin} aesthetic variable.}
 
-\item{ymax}{Unquoted ymax aesthetic variable.}
+\item{ymax}{Unquoted \code{ymax} aesthetic variable.}
 
-\item{yend}{Unquoted yend aesthetic variable.}
+\item{yend}{Unquoted \code{yend} aesthetic variable.}
 
-\item{z}{Unquoted z aesthetic variable.}
+\item{z}{Unquoted \code{z} aesthetic variable.}
 
-\item{col}{Unquoted col and fill aesthetic variable.}
+\item{col}{Unquoted \code{col} and \code{fill} aesthetic variable.}
 
-\item{alpha}{Unquoted alpha aesthetic variable.}
+\item{alpha}{Unquoted \code{alpha} aesthetic variable.}
 
-\item{facet}{Unquoted facet aesthetic variable.}
+\item{facet}{Unquoted \code{facet} aesthetic variable.}
 
 \item{facet2}{Unquoted second facet variable.}
 
-\item{group}{Unquoted group aesthetic variable.}
+\item{group}{Unquoted \code{group} aesthetic variable.}
 
-\item{subgroup}{Unquoted subgroup aesthetic variable.}
+\item{subgroup}{Unquoted \code{subgroup} aesthetic variable.}
 
-\item{label}{Unquoted label aesthetic variable.}
+\item{label}{Unquoted \code{label} aesthetic variable.}
 
-\item{text}{Unquoted text aesthetic variable.}
+\item{text}{Unquoted \code{text} aesthetic variable.}
 
-\item{sample}{Unquoted sample aesthetic variable.}
+\item{sample}{Unquoted \code{sample} aesthetic variable.}
 
-\item{mapping}{Set of additional aesthetic mappings within the ggplot2::aes function for non-supported aesthetics (e.g. shape, linetype, linewidth, or size) or for delayed evaluation.}
+\item{mapping}{Set of additional aesthetic mappings within \code{ggplot2::aes()} for non-supported aesthetics (e.g. \code{shape}, \code{linetype}, \code{linewidth}, or \code{size}) or for delayed evaluation.}
 
-\item{x_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{x_breaks, y_breaks}{A \verb{scales::breaks_*} function (e.g. \code{\link[scales:breaks_pretty]{scales::breaks_pretty()}}), or a vector of breaks.}
 
-\item{x_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{x_expand, y_expand}{Padding to the limits with the \code{ggplot2::expansion()} function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{x_expand_limits}{For a continuous x variable, any values that the limits should encompass (e.g. 0).}
+\item{x_expand_limits, y_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{x_gridlines}{TRUE or FALSE for vertical x gridlines. NULL guesses based on the classes of the x and y.}
+\item{x_gridlines}{\code{TRUE} or \code{FALSE} for vertical \code{x} gridlines. \code{NULL} guesses based on the classes of the x and y.}
 
-\item{x_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{x_labels, y_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{\link[scales:label_number]{scales::label_comma()}}), or a vector of labels.}
 
-\item{x_limits}{A vector of length 2 to determine the limits of the axis.}
+\item{x_limits, y_limits}{A vector of length 2 to determine the limits of the axis.}
 
-\item{x_oob}{For a continuous x variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{x_oob, y_oob}{For a continuous \code{x} variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
-\item{x_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
+\item{x_sec_axis, y_sec_axis}{A secondary axis using \code{ggplot2::sec_axis()} or \code{ggplot2::dup_axis()}.}
 
-\item{x_title}{Axis title string. Use "" for no title.}
+\item{x_title, y_title}{Axis title string. Use \code{""} for no title.}
 
-\item{x_transform}{For a numeric x variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{x_transform, y_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{y_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{y_gridlines}{\code{TRUE} or \code{FALSE} of horizontal \code{y} gridlines. \code{NULL} guesses based on the classes of the \code{x} and \code{y}.}
 
-\item{y_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
-
-\item{y_expand_limits}{For a continuous y variable, any values that the limits should encompass (e.g. 0).}
-
-\item{y_gridlines}{TRUE or FALSE of horizontal y gridlines. NULL guesses based on the classes of the x and y.}
-
-\item{y_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
-
-\item{y_limits}{A vector of length 2 to determine the limits of the axis.}
-
-\item{y_oob}{For a continuous y variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
-
-\item{y_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
-
-\item{y_title}{Axis title string. Use "" for no title.}
-
-\item{y_transform}{For a numeric y variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
-
-\item{col_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{col_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{col_continuous_type}{For a continuous variable, whether to colour as a "gradient" or in "steps". Defaults to "gradient".}
 
 \item{col_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{col_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{col_expand}{Padding to the limits with \code{ggplot2::expansion()}, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{col_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{col_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{col_legend_ncol}{The number of columns for the legend elements.}
+\item{col_legend_ncol, col_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{col_legend_nrow}{The number of rows for the legend elements.}
-
-\item{col_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{col_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{col_limits}{A vector to determine the limits of the scale.}
 
-\item{col_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{col_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{col_pal}{colours to use. A character vector of hex codes (or names).}
 
-\item{col_pal_na}{colour to use for NA values. A character vector of a hex code (or name).}
+\item{col_pal_na}{colour to use for \code{NA} values. A character vector of a hex code (or name).}
 
-\item{col_rescale}{For a continuous variable, a scales::rescale function.}
+\item{col_rescale}{For a continuous variable, a \code{scales::rescale} function.}
 
 \item{col_title}{Legend title string. Use "" for no title.}
 
-\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{alpha_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{alpha_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{alpha_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{alpha_legend_ncol}{The number of columns for the legend elements.}
+\item{alpha_legend_ncol, alpha_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{alpha_legend_nrow}{The number of rows for the legend elements.}
-
-\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{alpha_limits}{A vector to determine the limits of the scale.}
 
-\item{alpha_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{alpha_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{alpha_pal}{Alpha values to use as a numeric vector. For a continuous variable, a range is only needed.}
 
-\item{alpha_pal_na}{Alpha value to use for the NA value.}
+\item{alpha_pal_na}{Alpha value to use for the \code{NA} value.}
 
-\item{alpha_title}{Legend title string. Use "" for no title.}
+\item{alpha_title}{Legend title string. Use \code{""} for no title.}
 
-\item{alpha_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{alpha_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the transform_ prefix (e.g. "log10").}
 
 \item{facet_axes}{Whether to add interior axes and ticks with "margins", "all", "all_x", or "all_y".}
 
 \item{facet_axis_labels}{Whether to add interior axis labels with "margins", "all", "all_x", or "all_y".}
 
-\item{facet_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
+\item{facet_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
 
 \item{facet_labels_position}{When the facet layout is "wrap", the position of the facet labels. Either "top", "right", "bottom" or "left".}
 
 \item{facet_labels_switch}{When the facet layout is "grid", whether to switch the facet labels to the opposite side of the plot. Either "x", "y" or "both".}
 
-\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If NULL and a single facet (or facet2) argument is provided, then defaults to "wrap". If NULL and both facet and facet2 arguments are provided, defaults to "grid".}
+\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If \code{NULL} and a single \code{facet} (or \code{facet2}) argument is provided, then defaults to "wrap". If \code{NULL} and both facet and facet2 arguments are provided, defaults to "grid".}
 
 \item{facet_ncol}{The number of columns of facets. Only applies to a facet layout of "wrap".}
 
@@ -268,15 +246,15 @@ gg_smooth(
 
 \item{caption}{Caption title string.}
 
-\item{titles}{A function to format unspecified titles. Defaults to snakecase::to_sentence_case.}
+\item{titles}{A function to format unspecified titles. Defaults to \code{snakecase::to_sentence_case}.}
 
-\item{flipped}{TRUE or FALSE or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
+\item{flipped}{\code{TRUE} or \code{FALSE} or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
 }
 \value{
 A ggplot object.
 }
 \description{
-Create a smooth ggplot with a wrapper around ggplot() + geom_smooth.
+Create a smooth ggplot with a wrapper around \code{ggplot()} + \link[ggplot2:geom_smooth]{geom_smooth()}.
 }
 \examples{
 

--- a/man/gg_step.Rd
+++ b/man/gg_step.Rd
@@ -98,161 +98,139 @@ gg_step(
 \arguments{
 \item{data}{A data frame or tibble.}
 
-\item{...}{Other arguments passed to within a params list in the layer function.}
+\item{...}{Other arguments passed to within a \code{params} list in \code{layer()}.}
 
 \item{stat}{A statistical transformation to use on the data. A snakecase character string of a ggproto Stat subclass object minus the Stat prefix (e.g. "identity").}
 
-\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a position_* function that outputs a ggproto Position subclass object (e.g. ggplot2::position_identity()).}
+\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a \verb{position_*()} function that outputs a ggproto Position subclass object (e.g. \code{ggplot2::position_identity()}).}
 
-\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. ggplot2::coord_cartesian()).}
+\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. \code{\link[ggplot2:coord_cartesian]{ggplot2::coord_cartesian()}}).}
 
-\item{theme}{A ggplot2 theme (e.g. light_mode_b(), dark_mode_rt() or ggplot2::theme_grey()).}
+\item{theme}{A ggplot2 theme (e.g. \code{\link[=light_mode_b]{light_mode_b()}}, \code{\link[=dark_mode_rt]{dark_mode_rt()}} or \code{\link[ggplot2:ggtheme]{ggplot2::theme_grey()}}).}
 
-\item{x}{Unquoted x aesthetic variable.}
+\item{x}{Unquoted \code{x} aesthetic variable.}
 
-\item{xmin}{Unquoted xmin aesthetic variable.}
+\item{xmin}{Unquoted \code{xmin} aesthetic variable.}
 
-\item{xmax}{Unquoted xmax aesthetic variable.}
+\item{xmax}{Unquoted \code{xmax} aesthetic variable.}
 
-\item{xend}{Unquoted xend aesthetic variable.}
+\item{xend}{Unquoted \code{xend} aesthetic variable.}
 
-\item{y}{Unquoted y aesthetic variable.}
+\item{y}{Unquoted \code{y} aesthetic variable.}
 
-\item{ymin}{Unquoted ymin aesthetic variable.}
+\item{ymin}{Unquoted \code{ymin} aesthetic variable.}
 
-\item{ymax}{Unquoted ymax aesthetic variable.}
+\item{ymax}{Unquoted \code{ymax} aesthetic variable.}
 
-\item{yend}{Unquoted yend aesthetic variable.}
+\item{yend}{Unquoted \code{yend} aesthetic variable.}
 
-\item{z}{Unquoted z aesthetic variable.}
+\item{z}{Unquoted \code{z} aesthetic variable.}
 
-\item{col}{Unquoted col and fill aesthetic variable.}
+\item{col}{Unquoted \code{col} and \code{fill} aesthetic variable.}
 
-\item{alpha}{Unquoted alpha aesthetic variable.}
+\item{alpha}{Unquoted \code{alpha} aesthetic variable.}
 
-\item{facet}{Unquoted facet aesthetic variable.}
+\item{facet}{Unquoted \code{facet} aesthetic variable.}
 
 \item{facet2}{Unquoted second facet variable.}
 
-\item{group}{Unquoted group aesthetic variable.}
+\item{group}{Unquoted \code{group} aesthetic variable.}
 
-\item{subgroup}{Unquoted subgroup aesthetic variable.}
+\item{subgroup}{Unquoted \code{subgroup} aesthetic variable.}
 
-\item{label}{Unquoted label aesthetic variable.}
+\item{label}{Unquoted \code{label} aesthetic variable.}
 
-\item{text}{Unquoted text aesthetic variable.}
+\item{text}{Unquoted \code{text} aesthetic variable.}
 
-\item{sample}{Unquoted sample aesthetic variable.}
+\item{sample}{Unquoted \code{sample} aesthetic variable.}
 
-\item{mapping}{Set of additional aesthetic mappings within the ggplot2::aes function for non-supported aesthetics (e.g. shape, linetype, linewidth, or size) or for delayed evaluation.}
+\item{mapping}{Set of additional aesthetic mappings within \code{ggplot2::aes()} for non-supported aesthetics (e.g. \code{shape}, \code{linetype}, \code{linewidth}, or \code{size}) or for delayed evaluation.}
 
-\item{x_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{x_breaks, y_breaks}{A \verb{scales::breaks_*} function (e.g. \code{\link[scales:breaks_pretty]{scales::breaks_pretty()}}), or a vector of breaks.}
 
-\item{x_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{x_expand, y_expand}{Padding to the limits with the \code{ggplot2::expansion()} function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{x_expand_limits}{For a continuous x variable, any values that the limits should encompass (e.g. 0).}
+\item{x_expand_limits, y_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{x_gridlines}{TRUE or FALSE for vertical x gridlines. NULL guesses based on the classes of the x and y.}
+\item{x_gridlines}{\code{TRUE} or \code{FALSE} for vertical \code{x} gridlines. \code{NULL} guesses based on the classes of the x and y.}
 
-\item{x_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{x_labels, y_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{\link[scales:label_number]{scales::label_comma()}}), or a vector of labels.}
 
-\item{x_limits}{A vector of length 2 to determine the limits of the axis.}
+\item{x_limits, y_limits}{A vector of length 2 to determine the limits of the axis.}
 
-\item{x_oob}{For a continuous x variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{x_oob, y_oob}{For a continuous \code{x} variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
-\item{x_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
+\item{x_sec_axis, y_sec_axis}{A secondary axis using \code{ggplot2::sec_axis()} or \code{ggplot2::dup_axis()}.}
 
-\item{x_title}{Axis title string. Use "" for no title.}
+\item{x_title, y_title}{Axis title string. Use \code{""} for no title.}
 
-\item{x_transform}{For a numeric x variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{x_transform, y_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{y_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{y_gridlines}{\code{TRUE} or \code{FALSE} of horizontal \code{y} gridlines. \code{NULL} guesses based on the classes of the \code{x} and \code{y}.}
 
-\item{y_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
-
-\item{y_expand_limits}{For a continuous y variable, any values that the limits should encompass (e.g. 0).}
-
-\item{y_gridlines}{TRUE or FALSE of horizontal y gridlines. NULL guesses based on the classes of the x and y.}
-
-\item{y_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
-
-\item{y_limits}{A vector of length 2 to determine the limits of the axis.}
-
-\item{y_oob}{For a continuous y variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
-
-\item{y_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
-
-\item{y_title}{Axis title string. Use "" for no title.}
-
-\item{y_transform}{For a numeric y variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
-
-\item{col_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{col_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{col_continuous_type}{For a continuous variable, whether to colour as a "gradient" or in "steps". Defaults to "gradient".}
 
 \item{col_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{col_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{col_expand}{Padding to the limits with \code{ggplot2::expansion()}, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{col_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{col_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{col_legend_ncol}{The number of columns for the legend elements.}
+\item{col_legend_ncol, col_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{col_legend_nrow}{The number of rows for the legend elements.}
-
-\item{col_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{col_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{col_limits}{A vector to determine the limits of the scale.}
 
-\item{col_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{col_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{col_pal}{colours to use. A character vector of hex codes (or names).}
 
-\item{col_pal_na}{colour to use for NA values. A character vector of a hex code (or name).}
+\item{col_pal_na}{colour to use for \code{NA} values. A character vector of a hex code (or name).}
 
-\item{col_rescale}{For a continuous variable, a scales::rescale function.}
+\item{col_rescale}{For a continuous variable, a \code{scales::rescale} function.}
 
 \item{col_title}{Legend title string. Use "" for no title.}
 
-\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{alpha_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{alpha_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{alpha_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{alpha_legend_ncol}{The number of columns for the legend elements.}
+\item{alpha_legend_ncol, alpha_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{alpha_legend_nrow}{The number of rows for the legend elements.}
-
-\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{alpha_limits}{A vector to determine the limits of the scale.}
 
-\item{alpha_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{alpha_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{alpha_pal}{Alpha values to use as a numeric vector. For a continuous variable, a range is only needed.}
 
-\item{alpha_pal_na}{Alpha value to use for the NA value.}
+\item{alpha_pal_na}{Alpha value to use for the \code{NA} value.}
 
-\item{alpha_title}{Legend title string. Use "" for no title.}
+\item{alpha_title}{Legend title string. Use \code{""} for no title.}
 
-\item{alpha_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{alpha_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the transform_ prefix (e.g. "log10").}
 
 \item{facet_axes}{Whether to add interior axes and ticks with "margins", "all", "all_x", or "all_y".}
 
 \item{facet_axis_labels}{Whether to add interior axis labels with "margins", "all", "all_x", or "all_y".}
 
-\item{facet_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
+\item{facet_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
 
 \item{facet_labels_position}{When the facet layout is "wrap", the position of the facet labels. Either "top", "right", "bottom" or "left".}
 
 \item{facet_labels_switch}{When the facet layout is "grid", whether to switch the facet labels to the opposite side of the plot. Either "x", "y" or "both".}
 
-\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If NULL and a single facet (or facet2) argument is provided, then defaults to "wrap". If NULL and both facet and facet2 arguments are provided, defaults to "grid".}
+\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If \code{NULL} and a single \code{facet} (or \code{facet2}) argument is provided, then defaults to "wrap". If \code{NULL} and both facet and facet2 arguments are provided, defaults to "grid".}
 
 \item{facet_ncol}{The number of columns of facets. Only applies to a facet layout of "wrap".}
 
@@ -268,15 +246,15 @@ gg_step(
 
 \item{caption}{Caption title string.}
 
-\item{titles}{A function to format unspecified titles. Defaults to snakecase::to_sentence_case.}
+\item{titles}{A function to format unspecified titles. Defaults to \code{snakecase::to_sentence_case}.}
 
-\item{flipped}{TRUE or FALSE or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
+\item{flipped}{\code{TRUE} or \code{FALSE} or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
 }
 \value{
 A ggplot object.
 }
 \description{
-Create a step plot with a wrapper around ggplot() + geom_step.
+Create a step plot with a wrapper around \code{ggplot()} + \link[ggplot2:geom_path]{geom_step()}.
 }
 \examples{
 

--- a/man/gg_text.Rd
+++ b/man/gg_text.Rd
@@ -98,161 +98,139 @@ gg_text(
 \arguments{
 \item{data}{A data frame or tibble.}
 
-\item{...}{Other arguments passed to within a params list in the layer function.}
+\item{...}{Other arguments passed to within a \code{params} list in \code{layer()}.}
 
 \item{stat}{A statistical transformation to use on the data. A snakecase character string of a ggproto Stat subclass object minus the Stat prefix (e.g. "identity").}
 
-\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a position_* function that outputs a ggproto Position subclass object (e.g. ggplot2::position_identity()).}
+\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a \verb{position_*()} function that outputs a ggproto Position subclass object (e.g. \code{ggplot2::position_identity()}).}
 
-\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. ggplot2::coord_cartesian()).}
+\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. \code{\link[ggplot2:coord_cartesian]{ggplot2::coord_cartesian()}}).}
 
-\item{theme}{A ggplot2 theme (e.g. light_mode_b(), dark_mode_rt() or ggplot2::theme_grey()).}
+\item{theme}{A ggplot2 theme (e.g. \code{\link[=light_mode_b]{light_mode_b()}}, \code{\link[=dark_mode_rt]{dark_mode_rt()}} or \code{\link[ggplot2:ggtheme]{ggplot2::theme_grey()}}).}
 
-\item{x}{Unquoted x aesthetic variable.}
+\item{x}{Unquoted \code{x} aesthetic variable.}
 
-\item{xmin}{Unquoted xmin aesthetic variable.}
+\item{xmin}{Unquoted \code{xmin} aesthetic variable.}
 
-\item{xmax}{Unquoted xmax aesthetic variable.}
+\item{xmax}{Unquoted \code{xmax} aesthetic variable.}
 
-\item{xend}{Unquoted xend aesthetic variable.}
+\item{xend}{Unquoted \code{xend} aesthetic variable.}
 
-\item{y}{Unquoted y aesthetic variable.}
+\item{y}{Unquoted \code{y} aesthetic variable.}
 
-\item{ymin}{Unquoted ymin aesthetic variable.}
+\item{ymin}{Unquoted \code{ymin} aesthetic variable.}
 
-\item{ymax}{Unquoted ymax aesthetic variable.}
+\item{ymax}{Unquoted \code{ymax} aesthetic variable.}
 
-\item{yend}{Unquoted yend aesthetic variable.}
+\item{yend}{Unquoted \code{yend} aesthetic variable.}
 
-\item{z}{Unquoted z aesthetic variable.}
+\item{z}{Unquoted \code{z} aesthetic variable.}
 
-\item{col}{Unquoted col and fill aesthetic variable.}
+\item{col}{Unquoted \code{col} and \code{fill} aesthetic variable.}
 
-\item{alpha}{Unquoted alpha aesthetic variable.}
+\item{alpha}{Unquoted \code{alpha} aesthetic variable.}
 
-\item{facet}{Unquoted facet aesthetic variable.}
+\item{facet}{Unquoted \code{facet} aesthetic variable.}
 
 \item{facet2}{Unquoted second facet variable.}
 
-\item{group}{Unquoted group aesthetic variable.}
+\item{group}{Unquoted \code{group} aesthetic variable.}
 
-\item{subgroup}{Unquoted subgroup aesthetic variable.}
+\item{subgroup}{Unquoted \code{subgroup} aesthetic variable.}
 
-\item{label}{Unquoted label aesthetic variable.}
+\item{label}{Unquoted \code{label} aesthetic variable.}
 
-\item{text}{Unquoted text aesthetic variable.}
+\item{text}{Unquoted \code{text} aesthetic variable.}
 
-\item{sample}{Unquoted sample aesthetic variable.}
+\item{sample}{Unquoted \code{sample} aesthetic variable.}
 
-\item{mapping}{Set of additional aesthetic mappings within the ggplot2::aes function for non-supported aesthetics (e.g. shape, linetype, linewidth, or size) or for delayed evaluation.}
+\item{mapping}{Set of additional aesthetic mappings within \code{ggplot2::aes()} for non-supported aesthetics (e.g. \code{shape}, \code{linetype}, \code{linewidth}, or \code{size}) or for delayed evaluation.}
 
-\item{x_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{x_breaks, y_breaks}{A \verb{scales::breaks_*} function (e.g. \code{\link[scales:breaks_pretty]{scales::breaks_pretty()}}), or a vector of breaks.}
 
-\item{x_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{x_expand, y_expand}{Padding to the limits with the \code{ggplot2::expansion()} function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{x_expand_limits}{For a continuous x variable, any values that the limits should encompass (e.g. 0).}
+\item{x_expand_limits, y_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{x_gridlines}{TRUE or FALSE for vertical x gridlines. NULL guesses based on the classes of the x and y.}
+\item{x_gridlines}{\code{TRUE} or \code{FALSE} for vertical \code{x} gridlines. \code{NULL} guesses based on the classes of the x and y.}
 
-\item{x_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{x_labels, y_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{\link[scales:label_number]{scales::label_comma()}}), or a vector of labels.}
 
-\item{x_limits}{A vector of length 2 to determine the limits of the axis.}
+\item{x_limits, y_limits}{A vector of length 2 to determine the limits of the axis.}
 
-\item{x_oob}{For a continuous x variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{x_oob, y_oob}{For a continuous \code{x} variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
-\item{x_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
+\item{x_sec_axis, y_sec_axis}{A secondary axis using \code{ggplot2::sec_axis()} or \code{ggplot2::dup_axis()}.}
 
-\item{x_title}{Axis title string. Use "" for no title.}
+\item{x_title, y_title}{Axis title string. Use \code{""} for no title.}
 
-\item{x_transform}{For a numeric x variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{x_transform, y_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{y_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{y_gridlines}{\code{TRUE} or \code{FALSE} of horizontal \code{y} gridlines. \code{NULL} guesses based on the classes of the \code{x} and \code{y}.}
 
-\item{y_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
-
-\item{y_expand_limits}{For a continuous y variable, any values that the limits should encompass (e.g. 0).}
-
-\item{y_gridlines}{TRUE or FALSE of horizontal y gridlines. NULL guesses based on the classes of the x and y.}
-
-\item{y_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
-
-\item{y_limits}{A vector of length 2 to determine the limits of the axis.}
-
-\item{y_oob}{For a continuous y variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
-
-\item{y_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
-
-\item{y_title}{Axis title string. Use "" for no title.}
-
-\item{y_transform}{For a numeric y variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
-
-\item{col_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{col_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{col_continuous_type}{For a continuous variable, whether to colour as a "gradient" or in "steps". Defaults to "gradient".}
 
 \item{col_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{col_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{col_expand}{Padding to the limits with \code{ggplot2::expansion()}, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{col_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{col_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{col_legend_ncol}{The number of columns for the legend elements.}
+\item{col_legend_ncol, col_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{col_legend_nrow}{The number of rows for the legend elements.}
-
-\item{col_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{col_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{col_limits}{A vector to determine the limits of the scale.}
 
-\item{col_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{col_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{col_pal}{colours to use. A character vector of hex codes (or names).}
 
-\item{col_pal_na}{colour to use for NA values. A character vector of a hex code (or name).}
+\item{col_pal_na}{colour to use for \code{NA} values. A character vector of a hex code (or name).}
 
-\item{col_rescale}{For a continuous variable, a scales::rescale function.}
+\item{col_rescale}{For a continuous variable, a \code{scales::rescale} function.}
 
 \item{col_title}{Legend title string. Use "" for no title.}
 
-\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{alpha_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{alpha_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{alpha_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{alpha_legend_ncol}{The number of columns for the legend elements.}
+\item{alpha_legend_ncol, alpha_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{alpha_legend_nrow}{The number of rows for the legend elements.}
-
-\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{alpha_limits}{A vector to determine the limits of the scale.}
 
-\item{alpha_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{alpha_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{alpha_pal}{Alpha values to use as a numeric vector. For a continuous variable, a range is only needed.}
 
-\item{alpha_pal_na}{Alpha value to use for the NA value.}
+\item{alpha_pal_na}{Alpha value to use for the \code{NA} value.}
 
-\item{alpha_title}{Legend title string. Use "" for no title.}
+\item{alpha_title}{Legend title string. Use \code{""} for no title.}
 
-\item{alpha_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{alpha_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the transform_ prefix (e.g. "log10").}
 
 \item{facet_axes}{Whether to add interior axes and ticks with "margins", "all", "all_x", or "all_y".}
 
 \item{facet_axis_labels}{Whether to add interior axis labels with "margins", "all", "all_x", or "all_y".}
 
-\item{facet_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
+\item{facet_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
 
 \item{facet_labels_position}{When the facet layout is "wrap", the position of the facet labels. Either "top", "right", "bottom" or "left".}
 
 \item{facet_labels_switch}{When the facet layout is "grid", whether to switch the facet labels to the opposite side of the plot. Either "x", "y" or "both".}
 
-\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If NULL and a single facet (or facet2) argument is provided, then defaults to "wrap". If NULL and both facet and facet2 arguments are provided, defaults to "grid".}
+\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If \code{NULL} and a single \code{facet} (or \code{facet2}) argument is provided, then defaults to "wrap". If \code{NULL} and both facet and facet2 arguments are provided, defaults to "grid".}
 
 \item{facet_ncol}{The number of columns of facets. Only applies to a facet layout of "wrap".}
 
@@ -268,15 +246,15 @@ gg_text(
 
 \item{caption}{Caption title string.}
 
-\item{titles}{A function to format unspecified titles. Defaults to snakecase::to_sentence_case.}
+\item{titles}{A function to format unspecified titles. Defaults to \code{snakecase::to_sentence_case}.}
 
-\item{flipped}{TRUE or FALSE or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
+\item{flipped}{\code{TRUE} or \code{FALSE} or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
 }
 \value{
 A ggplot object.
 }
 \description{
-Create a text plot with a wrapper around ggplot() + geom_text.
+Create a text plot with a wrapper around \code{ggplot()} + \link[ggplot2:geom_text]{geom_text()}.
 }
 \examples{
 

--- a/man/gg_tile.Rd
+++ b/man/gg_tile.Rd
@@ -98,161 +98,139 @@ gg_tile(
 \arguments{
 \item{data}{A data frame or tibble.}
 
-\item{...}{Other arguments passed to within a params list in the layer function.}
+\item{...}{Other arguments passed to within a \code{params} list in \code{layer()}.}
 
 \item{stat}{A statistical transformation to use on the data. A snakecase character string of a ggproto Stat subclass object minus the Stat prefix (e.g. "identity").}
 
-\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a position_* function that outputs a ggproto Position subclass object (e.g. ggplot2::position_identity()).}
+\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a \verb{position_*()} function that outputs a ggproto Position subclass object (e.g. \code{ggplot2::position_identity()}).}
 
-\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. ggplot2::coord_cartesian()).}
+\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. \code{\link[ggplot2:coord_cartesian]{ggplot2::coord_cartesian()}}).}
 
-\item{theme}{A ggplot2 theme (e.g. light_mode_b(), dark_mode_rt() or ggplot2::theme_grey()).}
+\item{theme}{A ggplot2 theme (e.g. \code{\link[=light_mode_b]{light_mode_b()}}, \code{\link[=dark_mode_rt]{dark_mode_rt()}} or \code{\link[ggplot2:ggtheme]{ggplot2::theme_grey()}}).}
 
-\item{x}{Unquoted x aesthetic variable.}
+\item{x}{Unquoted \code{x} aesthetic variable.}
 
-\item{xmin}{Unquoted xmin aesthetic variable.}
+\item{xmin}{Unquoted \code{xmin} aesthetic variable.}
 
-\item{xmax}{Unquoted xmax aesthetic variable.}
+\item{xmax}{Unquoted \code{xmax} aesthetic variable.}
 
-\item{xend}{Unquoted xend aesthetic variable.}
+\item{xend}{Unquoted \code{xend} aesthetic variable.}
 
-\item{y}{Unquoted y aesthetic variable.}
+\item{y}{Unquoted \code{y} aesthetic variable.}
 
-\item{ymin}{Unquoted ymin aesthetic variable.}
+\item{ymin}{Unquoted \code{ymin} aesthetic variable.}
 
-\item{ymax}{Unquoted ymax aesthetic variable.}
+\item{ymax}{Unquoted \code{ymax} aesthetic variable.}
 
-\item{yend}{Unquoted yend aesthetic variable.}
+\item{yend}{Unquoted \code{yend} aesthetic variable.}
 
-\item{z}{Unquoted z aesthetic variable.}
+\item{z}{Unquoted \code{z} aesthetic variable.}
 
-\item{col}{Unquoted col and fill aesthetic variable.}
+\item{col}{Unquoted \code{col} and \code{fill} aesthetic variable.}
 
-\item{alpha}{Unquoted alpha aesthetic variable.}
+\item{alpha}{Unquoted \code{alpha} aesthetic variable.}
 
-\item{facet}{Unquoted facet aesthetic variable.}
+\item{facet}{Unquoted \code{facet} aesthetic variable.}
 
 \item{facet2}{Unquoted second facet variable.}
 
-\item{group}{Unquoted group aesthetic variable.}
+\item{group}{Unquoted \code{group} aesthetic variable.}
 
-\item{subgroup}{Unquoted subgroup aesthetic variable.}
+\item{subgroup}{Unquoted \code{subgroup} aesthetic variable.}
 
-\item{label}{Unquoted label aesthetic variable.}
+\item{label}{Unquoted \code{label} aesthetic variable.}
 
-\item{text}{Unquoted text aesthetic variable.}
+\item{text}{Unquoted \code{text} aesthetic variable.}
 
-\item{sample}{Unquoted sample aesthetic variable.}
+\item{sample}{Unquoted \code{sample} aesthetic variable.}
 
-\item{mapping}{Set of additional aesthetic mappings within the ggplot2::aes function for non-supported aesthetics (e.g. shape, linetype, linewidth, or size) or for delayed evaluation.}
+\item{mapping}{Set of additional aesthetic mappings within \code{ggplot2::aes()} for non-supported aesthetics (e.g. \code{shape}, \code{linetype}, \code{linewidth}, or \code{size}) or for delayed evaluation.}
 
-\item{x_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{x_breaks, y_breaks}{A \verb{scales::breaks_*} function (e.g. \code{\link[scales:breaks_pretty]{scales::breaks_pretty()}}), or a vector of breaks.}
 
-\item{x_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{x_expand, y_expand}{Padding to the limits with the \code{ggplot2::expansion()} function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{x_expand_limits}{For a continuous x variable, any values that the limits should encompass (e.g. 0).}
+\item{x_expand_limits, y_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{x_gridlines}{TRUE or FALSE for vertical x gridlines. NULL guesses based on the classes of the x and y.}
+\item{x_gridlines}{\code{TRUE} or \code{FALSE} for vertical \code{x} gridlines. \code{NULL} guesses based on the classes of the x and y.}
 
-\item{x_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{x_labels, y_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{\link[scales:label_number]{scales::label_comma()}}), or a vector of labels.}
 
-\item{x_limits}{A vector of length 2 to determine the limits of the axis.}
+\item{x_limits, y_limits}{A vector of length 2 to determine the limits of the axis.}
 
-\item{x_oob}{For a continuous x variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{x_oob, y_oob}{For a continuous \code{x} variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
-\item{x_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
+\item{x_sec_axis, y_sec_axis}{A secondary axis using \code{ggplot2::sec_axis()} or \code{ggplot2::dup_axis()}.}
 
-\item{x_title}{Axis title string. Use "" for no title.}
+\item{x_title, y_title}{Axis title string. Use \code{""} for no title.}
 
-\item{x_transform}{For a numeric x variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{x_transform, y_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{y_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{y_gridlines}{\code{TRUE} or \code{FALSE} of horizontal \code{y} gridlines. \code{NULL} guesses based on the classes of the \code{x} and \code{y}.}
 
-\item{y_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
-
-\item{y_expand_limits}{For a continuous y variable, any values that the limits should encompass (e.g. 0).}
-
-\item{y_gridlines}{TRUE or FALSE of horizontal y gridlines. NULL guesses based on the classes of the x and y.}
-
-\item{y_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
-
-\item{y_limits}{A vector of length 2 to determine the limits of the axis.}
-
-\item{y_oob}{For a continuous y variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
-
-\item{y_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
-
-\item{y_title}{Axis title string. Use "" for no title.}
-
-\item{y_transform}{For a numeric y variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
-
-\item{col_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{col_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{col_continuous_type}{For a continuous variable, whether to colour as a "gradient" or in "steps". Defaults to "gradient".}
 
 \item{col_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{col_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{col_expand}{Padding to the limits with \code{ggplot2::expansion()}, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{col_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{col_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{col_legend_ncol}{The number of columns for the legend elements.}
+\item{col_legend_ncol, col_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{col_legend_nrow}{The number of rows for the legend elements.}
-
-\item{col_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{col_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{col_limits}{A vector to determine the limits of the scale.}
 
-\item{col_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{col_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{col_pal}{colours to use. A character vector of hex codes (or names).}
 
-\item{col_pal_na}{colour to use for NA values. A character vector of a hex code (or name).}
+\item{col_pal_na}{colour to use for \code{NA} values. A character vector of a hex code (or name).}
 
-\item{col_rescale}{For a continuous variable, a scales::rescale function.}
+\item{col_rescale}{For a continuous variable, a \code{scales::rescale} function.}
 
 \item{col_title}{Legend title string. Use "" for no title.}
 
-\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{alpha_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{alpha_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{alpha_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{alpha_legend_ncol}{The number of columns for the legend elements.}
+\item{alpha_legend_ncol, alpha_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{alpha_legend_nrow}{The number of rows for the legend elements.}
-
-\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{alpha_limits}{A vector to determine the limits of the scale.}
 
-\item{alpha_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{alpha_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{alpha_pal}{Alpha values to use as a numeric vector. For a continuous variable, a range is only needed.}
 
-\item{alpha_pal_na}{Alpha value to use for the NA value.}
+\item{alpha_pal_na}{Alpha value to use for the \code{NA} value.}
 
-\item{alpha_title}{Legend title string. Use "" for no title.}
+\item{alpha_title}{Legend title string. Use \code{""} for no title.}
 
-\item{alpha_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{alpha_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the transform_ prefix (e.g. "log10").}
 
 \item{facet_axes}{Whether to add interior axes and ticks with "margins", "all", "all_x", or "all_y".}
 
 \item{facet_axis_labels}{Whether to add interior axis labels with "margins", "all", "all_x", or "all_y".}
 
-\item{facet_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
+\item{facet_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
 
 \item{facet_labels_position}{When the facet layout is "wrap", the position of the facet labels. Either "top", "right", "bottom" or "left".}
 
 \item{facet_labels_switch}{When the facet layout is "grid", whether to switch the facet labels to the opposite side of the plot. Either "x", "y" or "both".}
 
-\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If NULL and a single facet (or facet2) argument is provided, then defaults to "wrap". If NULL and both facet and facet2 arguments are provided, defaults to "grid".}
+\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If \code{NULL} and a single \code{facet} (or \code{facet2}) argument is provided, then defaults to "wrap". If \code{NULL} and both facet and facet2 arguments are provided, defaults to "grid".}
 
 \item{facet_ncol}{The number of columns of facets. Only applies to a facet layout of "wrap".}
 
@@ -268,15 +246,15 @@ gg_tile(
 
 \item{caption}{Caption title string.}
 
-\item{titles}{A function to format unspecified titles. Defaults to snakecase::to_sentence_case.}
+\item{titles}{A function to format unspecified titles. Defaults to \code{snakecase::to_sentence_case}.}
 
-\item{flipped}{TRUE or FALSE or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
+\item{flipped}{\code{TRUE} or \code{FALSE} or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
 }
 \value{
 A ggplot object.
 }
 \description{
-Create a tile plot with a wrapper around ggplot() + geom_tile.
+Create a tile plot with a wrapper around \code{ggplot()} + \link[ggplot2:geom_tile]{geom_tile()}.
 }
 \examples{
 

--- a/man/gg_violin.Rd
+++ b/man/gg_violin.Rd
@@ -98,161 +98,139 @@ gg_violin(
 \arguments{
 \item{data}{A data frame or tibble.}
 
-\item{...}{Other arguments passed to within a params list in the layer function.}
+\item{...}{Other arguments passed to within a \code{params} list in \code{layer()}.}
 
 \item{stat}{A statistical transformation to use on the data. A snakecase character string of a ggproto Stat subclass object minus the Stat prefix (e.g. "identity").}
 
-\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a position_* function that outputs a ggproto Position subclass object (e.g. ggplot2::position_identity()).}
+\item{position}{A position adjustment. A snakecase character string of a ggproto Position subclass object minus the Position prefix (e.g. "identity"), or a \verb{position_*()} function that outputs a ggproto Position subclass object (e.g. \code{ggplot2::position_identity()}).}
 
-\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. ggplot2::coord_cartesian()).}
+\item{coord}{A coordinate system. A coord_* function that outputs a constructed ggproto Coord subclass object (e.g. \code{\link[ggplot2:coord_cartesian]{ggplot2::coord_cartesian()}}).}
 
-\item{theme}{A ggplot2 theme (e.g. light_mode_b(), dark_mode_rt() or ggplot2::theme_grey()).}
+\item{theme}{A ggplot2 theme (e.g. \code{\link[=light_mode_b]{light_mode_b()}}, \code{\link[=dark_mode_rt]{dark_mode_rt()}} or \code{\link[ggplot2:ggtheme]{ggplot2::theme_grey()}}).}
 
-\item{x}{Unquoted x aesthetic variable.}
+\item{x}{Unquoted \code{x} aesthetic variable.}
 
-\item{xmin}{Unquoted xmin aesthetic variable.}
+\item{xmin}{Unquoted \code{xmin} aesthetic variable.}
 
-\item{xmax}{Unquoted xmax aesthetic variable.}
+\item{xmax}{Unquoted \code{xmax} aesthetic variable.}
 
-\item{xend}{Unquoted xend aesthetic variable.}
+\item{xend}{Unquoted \code{xend} aesthetic variable.}
 
-\item{y}{Unquoted y aesthetic variable.}
+\item{y}{Unquoted \code{y} aesthetic variable.}
 
-\item{ymin}{Unquoted ymin aesthetic variable.}
+\item{ymin}{Unquoted \code{ymin} aesthetic variable.}
 
-\item{ymax}{Unquoted ymax aesthetic variable.}
+\item{ymax}{Unquoted \code{ymax} aesthetic variable.}
 
-\item{yend}{Unquoted yend aesthetic variable.}
+\item{yend}{Unquoted \code{yend} aesthetic variable.}
 
-\item{z}{Unquoted z aesthetic variable.}
+\item{z}{Unquoted \code{z} aesthetic variable.}
 
-\item{col}{Unquoted col and fill aesthetic variable.}
+\item{col}{Unquoted \code{col} and \code{fill} aesthetic variable.}
 
-\item{alpha}{Unquoted alpha aesthetic variable.}
+\item{alpha}{Unquoted \code{alpha} aesthetic variable.}
 
-\item{facet}{Unquoted facet aesthetic variable.}
+\item{facet}{Unquoted \code{facet} aesthetic variable.}
 
 \item{facet2}{Unquoted second facet variable.}
 
-\item{group}{Unquoted group aesthetic variable.}
+\item{group}{Unquoted \code{group} aesthetic variable.}
 
-\item{subgroup}{Unquoted subgroup aesthetic variable.}
+\item{subgroup}{Unquoted \code{subgroup} aesthetic variable.}
 
-\item{label}{Unquoted label aesthetic variable.}
+\item{label}{Unquoted \code{label} aesthetic variable.}
 
-\item{text}{Unquoted text aesthetic variable.}
+\item{text}{Unquoted \code{text} aesthetic variable.}
 
-\item{sample}{Unquoted sample aesthetic variable.}
+\item{sample}{Unquoted \code{sample} aesthetic variable.}
 
-\item{mapping}{Set of additional aesthetic mappings within the ggplot2::aes function for non-supported aesthetics (e.g. shape, linetype, linewidth, or size) or for delayed evaluation.}
+\item{mapping}{Set of additional aesthetic mappings within \code{ggplot2::aes()} for non-supported aesthetics (e.g. \code{shape}, \code{linetype}, \code{linewidth}, or \code{size}) or for delayed evaluation.}
 
-\item{x_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{x_breaks, y_breaks}{A \verb{scales::breaks_*} function (e.g. \code{\link[scales:breaks_pretty]{scales::breaks_pretty()}}), or a vector of breaks.}
 
-\item{x_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{x_expand, y_expand}{Padding to the limits with the \code{ggplot2::expansion()} function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{x_expand_limits}{For a continuous x variable, any values that the limits should encompass (e.g. 0).}
+\item{x_expand_limits, y_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{x_gridlines}{TRUE or FALSE for vertical x gridlines. NULL guesses based on the classes of the x and y.}
+\item{x_gridlines}{\code{TRUE} or \code{FALSE} for vertical \code{x} gridlines. \code{NULL} guesses based on the classes of the x and y.}
 
-\item{x_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{x_labels, y_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{\link[scales:label_number]{scales::label_comma()}}), or a vector of labels.}
 
-\item{x_limits}{A vector of length 2 to determine the limits of the axis.}
+\item{x_limits, y_limits}{A vector of length 2 to determine the limits of the axis.}
 
-\item{x_oob}{For a continuous x variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{x_oob, y_oob}{For a continuous \code{x} variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
-\item{x_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
+\item{x_sec_axis, y_sec_axis}{A secondary axis using \code{ggplot2::sec_axis()} or \code{ggplot2::dup_axis()}.}
 
-\item{x_title}{Axis title string. Use "" for no title.}
+\item{x_title, y_title}{Axis title string. Use \code{""} for no title.}
 
-\item{x_transform}{For a numeric x variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{x_transform, y_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{y_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{y_gridlines}{\code{TRUE} or \code{FALSE} of horizontal \code{y} gridlines. \code{NULL} guesses based on the classes of the \code{x} and \code{y}.}
 
-\item{y_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
-
-\item{y_expand_limits}{For a continuous y variable, any values that the limits should encompass (e.g. 0).}
-
-\item{y_gridlines}{TRUE or FALSE of horizontal y gridlines. NULL guesses based on the classes of the x and y.}
-
-\item{y_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
-
-\item{y_limits}{A vector of length 2 to determine the limits of the axis.}
-
-\item{y_oob}{For a continuous y variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
-
-\item{y_sec_axis}{A secondary axis using the ggplot2::sec_axis or ggplot2::dup_axis function.}
-
-\item{y_title}{Axis title string. Use "" for no title.}
-
-\item{y_transform}{For a numeric y variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
-
-\item{col_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{col_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{col_continuous_type}{For a continuous variable, whether to colour as a "gradient" or in "steps". Defaults to "gradient".}
 
 \item{col_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{col_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{col_expand}{Padding to the limits with \code{ggplot2::expansion()}, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{col_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{col_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{col_legend_ncol}{The number of columns for the legend elements.}
+\item{col_legend_ncol, col_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{col_legend_nrow}{The number of rows for the legend elements.}
-
-\item{col_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{col_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{col_limits}{A vector to determine the limits of the scale.}
 
-\item{col_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{col_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{col_pal}{colours to use. A character vector of hex codes (or names).}
 
-\item{col_pal_na}{colour to use for NA values. A character vector of a hex code (or name).}
+\item{col_pal_na}{colour to use for \code{NA} values. A character vector of a hex code (or name).}
 
-\item{col_rescale}{For a continuous variable, a scales::rescale function.}
+\item{col_rescale}{For a continuous variable, a \code{scales::rescale} function.}
 
 \item{col_title}{Legend title string. Use "" for no title.}
 
-\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{col_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the \code{transform_} prefix (e.g. "log10").}
 
-\item{alpha_breaks}{A scales::breaks_* function (e.g. scales::breaks_pretty()), or a vector of breaks.}
+\item{alpha_breaks}{A \verb{scales::breaks_*} function (e.g. \code{scales::breaks_pretty()}), or a vector of breaks.}
 
 \item{alpha_expand_limits}{For a continuous variable, any values that the limits should encompass (e.g. 0).}
 
-\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. c(0, 0)).}
+\item{alpha_expand}{Padding to the limits with the ggplot2::expansion function, or a vector of length 2 (e.g. \code{c(0, 0)}).}
 
-\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a vector of labels.}
+\item{alpha_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a vector of labels.}
 
-\item{alpha_legend_ncol}{The number of columns for the legend elements.}
+\item{alpha_legend_ncol, alpha_legend_nrow}{The number of columns and rows for the legend elements.}
 
-\item{alpha_legend_nrow}{The number of rows for the legend elements.}
-
-\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to FALSE.}
+\item{alpha_legend_rev}{Reverse the elements of the legend. Defaults to \code{FALSE}.}
 
 \item{alpha_limits}{A vector to determine the limits of the scale.}
 
-\item{alpha_oob}{For a continuous variable, a scales::oob_* function of how to handle values outside of limits (e.g. scales::oob_keep). Defaults to scales::oob_keep.}
+\item{alpha_oob}{For a continuous variable, a \verb{scales::oob_*} function of how to handle values outside of limits (e.g. \code{scales::oob_keep}). Defaults to \code{scales::oob_keep}.}
 
 \item{alpha_pal}{Alpha values to use as a numeric vector. For a continuous variable, a range is only needed.}
 
-\item{alpha_pal_na}{Alpha value to use for the NA value.}
+\item{alpha_pal_na}{Alpha value to use for the \code{NA} value.}
 
-\item{alpha_title}{Legend title string. Use "" for no title.}
+\item{alpha_title}{Legend title string. Use \code{""} for no title.}
 
-\item{alpha_transform}{For a numeric variable, a transformation object (e.g. scales::transform_log10()) or character string of this minus the transform_ prefix (e.g. "log10").}
+\item{alpha_transform}{For a numeric variable, a transformation object (e.g. \code{scales::transform_log10()}) or character string of this minus the transform_ prefix (e.g. "log10").}
 
 \item{facet_axes}{Whether to add interior axes and ticks with "margins", "all", "all_x", or "all_y".}
 
 \item{facet_axis_labels}{Whether to add interior axis labels with "margins", "all", "all_x", or "all_y".}
 
-\item{facet_labels}{A function that takes the breaks as inputs (e.g. \(x) stingr::str_to_sentence(x) or scales::label_comma()), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
+\item{facet_labels}{A function that takes the breaks as inputs (e.g. \verb{\\(x) stringr::str_to_sentence(x)} or \code{scales::label_comma()}), or a named vector of labels (e.g. c("value1" = "label1", ...)).}
 
 \item{facet_labels_position}{When the facet layout is "wrap", the position of the facet labels. Either "top", "right", "bottom" or "left".}
 
 \item{facet_labels_switch}{When the facet layout is "grid", whether to switch the facet labels to the opposite side of the plot. Either "x", "y" or "both".}
 
-\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If NULL and a single facet (or facet2) argument is provided, then defaults to "wrap". If NULL and both facet and facet2 arguments are provided, defaults to "grid".}
+\item{facet_layout}{Whether the layout is to be "wrap" or "grid". If \code{NULL} and a single \code{facet} (or \code{facet2}) argument is provided, then defaults to "wrap". If \code{NULL} and both facet and facet2 arguments are provided, defaults to "grid".}
 
 \item{facet_ncol}{The number of columns of facets. Only applies to a facet layout of "wrap".}
 
@@ -268,15 +246,15 @@ gg_violin(
 
 \item{caption}{Caption title string.}
 
-\item{titles}{A function to format unspecified titles. Defaults to snakecase::to_sentence_case.}
+\item{titles}{A function to format unspecified titles. Defaults to \code{snakecase::to_sentence_case}.}
 
-\item{flipped}{TRUE or FALSE or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
+\item{flipped}{\code{TRUE} or \code{FALSE} or whether the plot is flipped. This affects the defaults of positional scale and gridlines.}
 }
 \value{
 A ggplot object.
 }
 \description{
-Create a violin plot with a wrapper around ggplot() + geom_violin.
+Create a violin plot with a wrapper around \code{ggplot()} + \link[ggplot2:geom_violin]{geom_violin()}.
 }
 \examples{
 

--- a/vignettes/ggblanket.Rmd
+++ b/vignettes/ggblanket.Rmd
@@ -47,7 +47,7 @@ Secondary objectives relate to:
 11. Flexibility to turn-off or fix either colour or fill
 12. Ability to add multiple `geom_*` layers
 13. Other key differences to ggplot2
-14. A `gg_blanket` function for extra `geom` flexibility
+14. A `gg_blanket()` function for extra `geom` flexibility
 
 ```{r setup}
 library(ggblanket)
@@ -210,7 +210,7 @@ ggblanket provides two families of themes: `light_mode_*` and `dark_mode_*`.
 
 Each theme family provides 4 variants that differ based on legend placement, which is represented by the suffix of the theme name of `rt`  (right-top), `r` (right-centre), `b` (bottom), and `t` top. 
 
-You can set the theme globally using `ggplot2::theme_set`. 
+You can set the theme globally using `ggplot2::theme_set()`. 
 
 ```{r, fig.asp=0.7}
 # theme_set(dark_mode_rt())
@@ -230,7 +230,7 @@ penguins |>
 
 ### 9. Access to other `geom_*` arguments via `...`
 
-The `...` argument provides accesss to all other arguments in the `geom_*` function. 
+The `...` argument provides access to all other arguments in the `geom_*()` function. 
 
 ```{r}
 penguins |>
@@ -336,9 +336,9 @@ Users can make plots with multiple layers with ggblanket by adding on `ggplot2::
 
 The `gg_*` function puts the aesthetic variables (i.e. `x`, `y`, `col`) within the wrapped `ggplot` function. Therefore, these aesthetics will inherit to any subsequent layers added. `facet` and `facet2` will likewise inherit - as will `data`, `coord` and `theme`.
 
-The `gg_*` function _should_ be appropriate to be the bottom layer of the plot. This is because the geoms will plot in order. 
+The `gg_*()` function _should_ be appropriate to be the bottom layer of the plot. This is because the geoms will plot in order. 
 
-All of the aesthetics required for the plot as a whole should generally be added into the `gg_*` function, including the `col` argument. If you do not want the first layer to have a colour and fill aesthetic, but you wish later layers to access this - use `gg_blanket` (as it defaults to a `blank` geom). 
+All of the aesthetics required for the plot as a whole should generally be added into the `gg_*` function, including the `col` argument. If you do not want the first layer to have a colour and fill aesthetic, but you wish later layers to access this - use `gg_blanket()` (as it defaults to a `blank` geom). 
 
 Use `*_expand_limits` or  `*_limits` to ensure the `gg_* function builds the limits appropriately for the plot as a whole.
 
@@ -448,7 +448,7 @@ This needs to be considered when you are using `x_limits` or `y_limits`, and you
 * `*_title` is equivalent to `ggplot2::labs(* = ...)`
 * Facet arguments `strip.position` and `switch` are renamed `facet_labels_position` and `facet_labels_switch`
 * y categorical variables are reversed, so that they are read from low levels (top) to high levels (bottom) * Logical variables are reversed, so that `TRUE` always comes before `FALSE`
-* Infinite values are treated as NA
+* Infinite values are treated as `NA`
  
 ### 14. A `gg_blanket` function for extra `geom` flexibility
 


### PR DESCRIPTION
* Adds code , back ticks to make documentation more readable
* Add link to original ggplot2 function to each `gg_*()` function
* [Document arguments together](https://roxygen2.r-lib.org/articles/reuse.html#multiple-parameters) to reduce duplication
* Add [links](https://roxygen2.r-lib.org/articles/rd-formatting.html#function-links) here and there,
* Add `()` to enable autolinking on the website.